### PR TITLE
Bug fixes

### DIFF
--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -1112,16 +1112,13 @@ const ContentMapper = () => {
                     >
                       <div className='cms-title'>
                         <Tooltip content={content?.type} position="bottom">
-                          {content?.type === "Content Type" 
+                          {content?.type === "content_type" 
                             ? <Icon icon={active == index ? "ContentModelsMediumActive" : "ContentModelsMedium"} size="small"  />
-                            : content?.type === "Global Field"
-                              ? <Icon icon={active == index ? "GlobalFieldsMediumActive" : "GlobalFieldsMedium"} size="small" />
-                              : <></>
+                            : <Icon icon={active == index ? "GlobalFieldsMediumActive" : "GlobalFieldsMedium"} size="small" />
                           }
                         </Tooltip>
                         {content?.otherCmsTitle && <span>{content?.otherCmsTitle}</span> }
                       </div>
-                      
                       
                       <div className='d-flex align-items-center ct-options'>
                         <span>


### PR DESCRIPTION
[CMG-233] - Content Mapper | LHS | Icons of Content type and Global fields are missing
[CMG-244] - Content Mapper | RHS | Source Cms fields -> Change text 'other cms type to 'source cms type'
[CMG-245] - Content Mapper | RHS | Mapping -> When you update the field type and save the changes, they do not reflect on the LHS immediately; you need to refresh the page to see the updates.