### PR TITLE
Fixed name error validation in popup modal

### DIFF
--- a/ui/src/components/Modal/index.tsx
+++ b/ui/src/components/Modal/index.tsx
@@ -60,7 +60,7 @@ const Modal = (props: ProjectModalProps) => {
       return;
     } else if (!/^[^\s].*$/.test(value)) { 
       setInputValue(false);
-      return 'Please enter a valid project name.';
+      return 'Please enter project name.';
     } else if (value && value?.length > 200) {
       setInputValue(false);
       return 'Project Name should not be more than 200 chars';


### PR DESCRIPTION
The name validation regex now allows project names to be a single character (as long as it's not a whitespace character) and can contain any number of characters after the first non-whitespace character.
[Screencast from 12-09-24 02:18:30 PM IST.webm](https://github.com/user-attachments/assets/040c3b57-b1e9-4c1e-96a0-0a23a3cefdfc)
