### PR TITLE
refactor:content mapper bugs

### DIFF
--- a/ui/src/components/ContentMapper/contentMapper.interface.ts
+++ b/ui/src/components/ContentMapper/contentMapper.interface.ts
@@ -93,6 +93,7 @@ export interface FieldMetadata {
   allow_json_rte?: boolean;
 }
 export interface ContentTypesSchema {
+  display_type: string;
   data_type?: 'text' | 'number' | 'isodate' | 'json' | 'file' | 'reference' | 'group' | 'boolean' | 'link';
   display_name: string;
   enum?: any;

--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -880,17 +880,13 @@ const ContentMapper = forwardRef(({projectData}: ContentMapperComponentProps, re
 
         }
         setIsFieldDeleted(true);
-        // console.log(deletedExstingField);
-        
-        delete existingField[item?.uid]
+        const index = selectedOptions?.indexOf(existingField[item?.uid]?.value?.label);
 
-     
-        const index = selectedOptions?.indexOf(`${item.contentstackField}`);
-        //console.log(index);
         if(index > -1){
-          selectedOptions.slice(index,1 )
+          selectedOptions.splice(index,1 );
+          
         }
-        
+        delete existingField[item?.uid]    
         
        }
     }
@@ -1027,6 +1023,8 @@ const ContentMapper = forwardRef(({projectData}: ContentMapperComponentProps, re
         return value?.data_type === 'json';
       case 'enum':
         return 'enum' in value;
+      case 'display_type':
+        return value?.display_type === 'dropdown';
       case 'allow_rich_text':
         return value?.field_metadata?.allow_rich_text === true;
       case 'Group':      
@@ -1151,7 +1149,7 @@ const ContentMapper = forwardRef(({projectData}: ContentMapperComponentProps, re
       'link': 'link',
       'reference': 'reference',
       'dropdown': 'enum',
-      'Droplist': 'enum',
+      'Droplist': 'display_type',
       'radio': 'enum'
     };
   


### PR DESCRIPTION
++ [CMG-305] : RHS | Existing content type -> 2 Groups -> When select 1 group and select below respective field and then switch to group 2 Then field of group 1 and Group 1 itself displays disabled
++ [CMG-310] : Content mapper | RHS -> Existing content type -> For the source dropdown field, it is mapping to both a checkbox and a dropdown