### PR TITLE
refactor:resolved content mapper bug [CMG-520]

### DIFF
--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -265,7 +265,7 @@ const ContentMapper = forwardRef(({handleStepChange}: contentMapperProps, ref: R
     label: contentTypeMapped?.[otherCmsTitle] ?? `Select ${isContentType ? 'Content Type' : 'Global Field'} from Existing Stack`,
     value: contentTypeMapped?.[otherCmsTitle] ?? `Select ${isContentType ? 'Content Type' : 'Global Field'} from Existing Stack`,
   });
-  const [otherCmsUid, setOtherCmsUid] = useState<string>(contentTypes[0]?.otherCmsUid);
+  const [otherCmsUid, setOtherCmsUid] = useState<string>(contentTypes?.[0]?.otherCmsUid);
 
   const [active, setActive] = useState<number | null>(0);
 


### PR DESCRIPTION
**Resolved following the bug :** 
++ [CMG-520] : Contentful | Content mapper | Existing stack is selected | when 2 single fields (any field) are present in existing CT and 3 fields present in Contentful then after mapping 2 CT's for 3rd Ct displays 0 match found which is incorrect