### PR TITLE
fix: resolve modular block merge failures during CT mapping

### DIFF
--- a/api/src/services/contentMapper.service.ts
+++ b/api/src/services/contentMapper.service.ts
@@ -442,7 +442,7 @@ const getExistingContentTypes = async (req: Request) => {
     let selectedContentType = null;
 
     if (contentTypeUID) {
-      const [res] = await safePromise(
+      const [err, res] = await safePromise(
         https({
           method: 'GET',
           url: `${baseUrl}/${contentTypeUID}`,
@@ -450,11 +450,13 @@ const getExistingContentTypes = async (req: Request) => {
         }),
       );
 
-      selectedContentType = {
-        title: res?.data?.content_type?.title,
-        uid: res?.data?.content_type?.uid,
-        schema: res?.data?.content_type?.schema,
-      };
+      if (!err) {
+        selectedContentType = {
+          title: res?.data?.content_type?.title,
+          uid: res?.data?.content_type?.uid,
+          schema: res?.data?.content_type?.schema,
+        };
+      }
     }
     return {
       contentTypes: processedContentTypes,
@@ -549,7 +551,7 @@ const getExistingGlobalFields = async (req: Request) => {
     let selectedGlobalField = null;
 
     if (globalFieldUID) {
-      const [res] = await safePromise(
+      const [err, res] = await safePromise(
         https({
           method: 'GET',
           url: `${baseUrl}/${globalFieldUID}`,
@@ -557,19 +559,13 @@ const getExistingGlobalFields = async (req: Request) => {
         }),
       );
 
-      // if (err) {
-      //   throw new Error(
-      //     `Error fetching selected global field: ${
-      //       err.response?.data || err.message
-      //     }`
-      //   );
-      // }
-
-      selectedGlobalField = {
-        title: res?.data?.global_field?.title,
-        uid: res?.data?.global_field?.uid,
-        schema: res?.data?.global_field?.schema,
-      };
+      if (!err) {
+        selectedGlobalField = {
+          title: res?.data?.global_field?.title,
+          uid: res?.data?.global_field?.uid,
+          schema: res?.data?.global_field?.schema,
+        };
+      }
     }
 
     return { globalFields: processedGlobalFields, selectedGlobalField };

--- a/api/src/utils/content-type-creator.utils.ts
+++ b/api/src/utils/content-type-creator.utils.ts
@@ -160,29 +160,24 @@ function buildFieldSchema(item: any, marketPlacePath: string, parentUid = ''): a
         }
       }
 
-      if (blockSchema.length > 0) {
-        blocks.push({
-          title: blockRawUid,  // Keep original for title
-          uid: blockUid,       // Snake case for uid
-          schema: removeDuplicateFields(blockSchema)
-        });
-      }
+      blocks.push({
+        title: blockRawUid,  // Keep original for title
+        uid: blockUid,       // Snake case for uid
+        schema: removeDuplicateFields(blockSchema)
+      });
     }
 
-    if (blocks.length > 0) {
-      return {
-        data_type: "blocks",
-        display_name: item?.display_name || rawUid,  // Keep original for display
-        field_metadata: {},
-        uid: itemUid,  // Snake case uid
-        multiple: true,
-        mandatory: false,
-        unique: false,
-        non_localizable: false,
-        blocks: removeDuplicateFields(blocks)
-      };
-    }
-    return null;
+    return {
+      data_type: "blocks",
+      display_name: item?.display_name || rawUid,  // Keep original for display
+      field_metadata: {},
+      uid: itemUid,  // Snake case uid
+      multiple: true,
+      mandatory: false,
+      unique: false,
+      non_localizable: false,
+      blocks: removeDuplicateFields(blocks)
+    };
   }
 
   if (fieldType === 'group') {
@@ -316,14 +311,25 @@ export function buildSchemaTree(fields: any[], parentUid = '', parentType = '', 
 
     if (hasChildren) {
       if (fieldType === 'modular_blocks') {
-        // Get modular block children
+        // Get modular block children (check both current and backup UIDs)
         const mbChildren = fields.filter(f => {
           if (!f) return false;
           const fUid = f?.contentstackFieldUid || '';
           if (!fUid || !fieldUid) return false;
-          return f?.contentstackFieldType === 'modular_blocks_child' &&
-            fUid.startsWith(fieldUid + '.') &&
-            !fUid.substring(fieldUid.length + 1).includes('.');
+          if (f?.contentstackFieldType !== 'modular_blocks_child') return false;
+
+          if (fUid.startsWith(fieldUid + '.') &&
+            !fUid.substring(fieldUid.length + 1).includes('.')) {
+            return true;
+          }
+
+          if (oldFieldUid && oldFieldUid !== fieldUid &&
+            fUid.startsWith(oldFieldUid + '.') &&
+            !fUid.substring(oldFieldUid.length + 1).includes('.')) {
+            return true;
+          }
+
+          return false;
         });
 
         result.schema = mbChildren.map(child => {


### PR DESCRIPTION
- Fix safePromise destructuring in getExistingContentTypes and getExistingGlobalFields that silently discarded API responses, preventing destination CT merge entirely
- Always emit modular block schema from buildFieldSchema even with no child blocks, so mergeTwoCts can append destination blocks
- Add oldFieldUid fallback to mbChildren filter in buildSchemaTree so renamed parent blocks still find child blocks using the original UID prefix