### PR TITLE
Fix empty locale dropdown on step 2 for Drupal

### DIFF
--- a/upload-api/src/services/drupal/index.ts
+++ b/upload-api/src/services/drupal/index.ts
@@ -24,6 +24,33 @@ const createDrupalMapper = async (
 
     const localeData = await extractLocale(config);
 
+     // 🔧 CRITICAL: Always normalize to lowercase before saving
+     const localeArray = Array.from(localeData).map((locale: any) => {
+      const localeValue = typeof locale === 'string' ? locale : (locale?.code || locale?.value || locale);
+      return (localeValue || '').toLowerCase();
+    }).filter((locale: string) => locale && locale.length > 0);
+
+    const mapperConfig = {
+      method: 'post',
+      maxBodyLength: Infinity,
+      url: `${process.env.NODE_BACKEND_API}/v2/migration/localeMapper/${projectId}`,
+      headers: {
+        app_token,
+        'Content-Type': 'application/json'
+      },
+      data: {
+        locale: localeArray
+      }
+    };
+
+    const mapRes = await axios.request(mapperConfig);
+    if (mapRes?.status == 200) {
+      logger.info('Legacy CMS', {
+        status: HTTP_CODES?.OK,
+        message: HTTP_TEXTS?.LOCALE_SAVED
+      });
+    }
+
     // Extract taxonomy vocabularies and save to drupalMigrationData
     await extractTaxonomy(config.mysql);
 
@@ -79,32 +106,6 @@ const createDrupalMapper = async (
       });
     }
 
-    // 🔧 CRITICAL: Always normalize to lowercase before saving
-    const localeArray = Array.from(localeData).map((locale: any) => {
-      const localeValue = typeof locale === 'string' ? locale : (locale?.code || locale?.value || locale);
-      return (localeValue || '').toLowerCase();
-    }).filter((locale: string) => locale && locale.length > 0);
-
-    const mapperConfig = {
-      method: 'post',
-      maxBodyLength: Infinity,
-      url: `${process.env.NODE_BACKEND_API}/v2/migration/localeMapper/${projectId}`,
-      headers: {
-        app_token,
-        'Content-Type': 'application/json'
-      },
-      data: {
-        locale: localeArray
-      }
-    };
-
-    const mapRes = await axios.request(mapperConfig);
-    if (mapRes?.status == 200) {
-      logger.info('Legacy CMS', {
-        status: HTTP_CODES?.OK,
-        message: HTTP_TEXTS?.LOCALE_SAVED
-      });
-    }
   } catch (err: any) {
     logger.warn('Validation error:', {
       status: HTTP_CODES?.UNAUTHORIZED,

--- a/upload-api/src/services/drupal/index.ts
+++ b/upload-api/src/services/drupal/index.ts
@@ -52,7 +52,7 @@ const createDrupalMapper = async (
     }
 
     // Extract taxonomy vocabularies and save to drupalMigrationData
-    await extractTaxonomy(config.mysql);
+    await extractTaxonomy(config?.mysql);
 
     const initialMapper = await createInitialMapper(config, affix);
 


### PR DESCRIPTION
Fixes empty locale dropdown on step 2 by moving the locale save API call before mapper creation. This change applies only to Drupal.

Ticket: https://contentstack.atlassian.net/browse/CMG-913