### PR TITLE
fix: update Card component's radio button logic and improve SaveChang…

### DIFF
--- a/ui/src/components/Common/Card/card.tsx
+++ b/ui/src/components/Common/Card/card.tsx
@@ -106,7 +106,7 @@ const Card = <T extends ICardType = ICardType>({
         }}
       >
         {isHovered || selectedCard?.[idField] === data?.[idField] ? (
-          <Radio checked={selectedCard?.id === data?.id} disabled={!isHovered} />
+          <Radio checked={selectedCard?.[idField] === data?.[idField]} disabled={!isHovered} />
         ) : (
           <></>
         )}

--- a/ui/src/components/Common/SaveChangesModal/index.tsx
+++ b/ui/src/components/Common/SaveChangesModal/index.tsx
@@ -11,9 +11,9 @@ interface Props {
   closeModal: () => void;
   isopen?: (flag: boolean) => void;
   otherCmsTitle?: string;
-  saveContentType?: () => void | Promise<void>;
+  saveContentType?: () => void;
   openContentType?: () => void;
-  changeStep?: () => void | Promise<void>;
+  changeStep?: () => void;
   dropdownStateChange: () => void;
 }
 
@@ -47,24 +47,24 @@ const SaveChangesModal = (props: Props) => {
           <Button
             buttonType="secondary"
             version={'v2'}
-            onClick={async () => {
+            onClick={ () => {
               props.closeModal();
               props?.dropdownStateChange();
               props.openContentType?.();
               props?.isopen?.(false);
-              await props?.changeStep?.();
+              props?.changeStep?.();
             }}
           >
             Don&apos;t Save
           </Button>
           <Button
             version={'v2'}
-            onClick={async () => {
+            onClick={ () => {
               props?.dropdownStateChange();
-              await props?.saveContentType?.();
+              props?.saveContentType?.();
               props.closeModal();
               props.openContentType?.();
-              await props?.changeStep?.();
+              props?.changeStep?.();
             }}
           >
             Save

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -67,27 +67,9 @@
     justify-content: space-between;
     min-height: 42px;
     padding: $px-8 $px-10 $px-8 $px-12;
-
-    > .ct-options {
-      align-items: center;
-      display: flex;
-      flex-shrink: 0;
-      gap: $space-10;
-
-      .ct-schema-preview-wrap {
-        align-items: center;
-        display: inline-flex;
-      }
-    }
-
     .ct-names {
-      align-items: center;
-      display: flex;
       font-size: $size-font-xl;
       line-height: normal;
-      min-height: 0;
-      min-width: 0;
-      text-align: left;
       width: calc(100% - 50px);
       .cms-title {
         align-items: center;
@@ -95,7 +77,6 @@
         max-height: 24px;
         white-space: nowrap;
         .tippy-wrapper {
-          align-items: center;
           display: flex;
         }
         span {
@@ -104,6 +85,9 @@
           overflow: hidden;
           text-overflow: ellipsis;
         }
+      }
+      .ct-options {
+        justify-content: flex-end;
       }
     }
     .schema-preview {
@@ -156,58 +140,56 @@
 .table-container {
   flex: 1 0 auto;
 }
-.content-mapper-container {
-  .table-wrapper {
-    flex: 1;
-    .TablePanel {
-      border-left: 0 none;
-      .TablePanel__list-count {
-        display: none;
-      }
+.table-wrapper {
+  flex: 1;
+  .TablePanel {
+    border-left: 0 none;
+    .TablePanel__list-count {
+      display: none;
     }
-    .Table {
-      border-left: 0 none;
-      min-height: 24.25rem;
-      .Table__body__row {
+  }
+  .Table {
+    border-left: 0 none;
+    min-height: 24.25rem;
+    .Table__body__row {
         .Table-select-body {
-          > .checkbox-wrapper {
-            align-items: flex-start;
-          }
+         >.checkbox-wrapper {
+          align-items: flex-start;
         }
-      }
-      .Table__body__column {
-        padding: 0 1.25rem;
-        &:not(:last-of-type) {
-          display: block;
-        }
-      }
-      .Table-select-body {
-        width: 68px;
-      }
-      .cms-field {
-        // text-transform: capitalize;
-        // overflow: hidden;
-        // text-overflow: ellipsis;
-        // white-space: nowrap;
-        // width: 445px;
-
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 1;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      .InstructionText {
-        font-size: $size-font-small;
-        margin: 0;
-      }
-      .EmptyStateWrapper {
-        margin-top: $px-20;
       }
     }
-    .import-cta {
+    .Table__body__column {
+      padding: 0 1.25rem;
+      &:not(:last-of-type) {
+        display: block;
+      }
+    }
+    .Table-select-body {
+      width: 68px;
+    }
+    .cms-field {
+      // text-transform: capitalize;
+      // overflow: hidden;
+      // text-overflow: ellipsis;
+      // white-space: nowrap;
+      // width: 445px;
+
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .InstructionText {
+      font-size: $size-font-small;
       margin: 0;
     }
+    .EmptyStateWrapper {
+      margin-top: $px-20;
+    }
+  }
+  .import-cta {
+    margin: 0;
   }
 }
 .disabled-field {
@@ -503,9 +485,14 @@ div .table-row {
   }
 }
 
+.select {
+  .tippy-wrapper {
+    display: inline; 
+  }
+}
+
 .entry-mapper-container {
   .Table {
-    
     // Force row layout alignment
     .Table__head,
     .Table__body__row {
@@ -513,12 +500,19 @@ div .table-row {
       width: 100%;
     }
 
-    // Keep the row-select (checkbox) cell at its fixed width and never shrink it
+    // Keep the row-select (checkbox) cell at its fixed width and never shrink it,
+    // and vertically center the checkbox so it lines up with the row text.
     .Table-select-head,
     .Table-select-body {
       flex: 0 0 68px !important;
       width: 68px !important;
       min-width: 68px !important;
+      display: flex !important;
+      align-items: center !important;
+
+      .checkbox-wrapper {
+        align-items: center !important;
+      }
     }
 
     // Target actual column containers

--- a/ui/src/components/LegacyCms/Actions/LoadSelectCms.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadSelectCms.tsx
@@ -128,9 +128,21 @@ const LoadSelectCms = (props: LoadSelectCmsProps) => {
       }
 
 
-      // Determine which CMS to set as selected
+      // Determine which CMS to set as selected.
+      // If a version is already selected (e.g. preserved across a restart / on revisit),
+      // keep it instead of wiping it back to DEFAULT_CMS_TYPE. Only auto-pick when there's
+      // a single matching version, and only fall back to default when nothing is selected.
       let finalSelectedCard: ICMSType | undefined;
-      if (filteredCmsData?.length === 1) {
+      const existingSelectedCms = newMigrationData?.legacy_cms?.selectedCms;
+      const existingStillValid =
+        !isEmptyString(existingSelectedCms?.cms_id) &&
+        filteredCmsData?.some(
+          (cms: ICMSType) => cms?.cms_id === existingSelectedCms?.cms_id
+        );
+
+      if (existingStillValid) {
+        finalSelectedCard = existingSelectedCms;
+      } else if (filteredCmsData?.length === 1) {
         finalSelectedCard = filteredCmsData[0];
       } else {
         finalSelectedCard = DEFAULT_CMS_TYPE;
@@ -144,7 +156,12 @@ const LoadSelectCms = (props: LoadSelectCmsProps) => {
         legacy_cms: {
           ...newMigrationData?.legacy_cms,
           selectedCms: finalSelectedCard, // Include selectedCms in this dispatch
-          selectedFileFormat: filteredCmsData[0]?.allowed_file_formats?.[0],
+          // Preserve the existing file format when a version was already selected; otherwise
+          // derive it from the resolved CMS card (data-driven via legacyCms.json).
+          selectedFileFormat:
+            newMigrationData?.legacy_cms?.selectedFileFormat?.fileformat_id
+              ? newMigrationData?.legacy_cms?.selectedFileFormat
+              : finalSelectedCard?.allowed_file_formats?.[0],
           affix: newMigrationData?.legacy_cms?.affix || 'cs', // Preserve or set default affix
           uploadedFile: {
             ...newMigrationData?.legacy_cms?.uploadedFile,

--- a/ui/src/components/LegacyCms/Actions/LoadSelectCms.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadSelectCms.tsx
@@ -156,12 +156,12 @@ const LoadSelectCms = (props: LoadSelectCmsProps) => {
         legacy_cms: {
           ...newMigrationData?.legacy_cms,
           selectedCms: finalSelectedCard, // Include selectedCms in this dispatch
-          // Preserve the existing file format when a version was already selected; otherwise
-          // derive it from the resolved CMS card (data-driven via legacyCms.json).
-          selectedFileFormat:
-            newMigrationData?.legacy_cms?.selectedFileFormat?.fileformat_id
-              ? newMigrationData?.legacy_cms?.selectedFileFormat
-              : finalSelectedCard?.allowed_file_formats?.[0],
+          // Keep the file format in sync with the resolved CMS: only preserve the existing
+          // format when the existing version is being preserved; otherwise derive it from
+          // the resolved card so we never end up with DEFAULT_CMS_TYPE + a stale format.
+          selectedFileFormat: existingStillValid
+            ? newMigrationData?.legacy_cms?.selectedFileFormat
+            : finalSelectedCard?.allowed_file_formats?.[0],
           affix: newMigrationData?.legacy_cms?.affix || 'cs', // Preserve or set default affix
           uploadedFile: {
             ...newMigrationData?.legacy_cms?.uploadedFile,

--- a/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
@@ -54,11 +54,14 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
 {
   const isSQL = fileFormatId?.toLowerCase() === 'sql';
   const newMigrationData = useSelector((state: RootState) => state?.migration?.newMigrationData);
+  const isValidated = newMigrationData?.legacy_cms?.uploadedFile?.isValidated;
   const [isEditing, setIsEditing] = useState((newMigrationData?.iteration > 1 && !newMigrationData?.legacy_cms?.uploadedFile?.isValidated) ? true : false);
   const [localPath, setLocalPath] = useState(fileDetails?.localPath || '');
   const dispatch = useDispatch();
   const currentPath = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath || fileDetails?.localPath || '';
   const handleEditFile = async () => {
+    // Once the file is validated, editing the path is disabled
+    if (isValidated) return;
     setIsEditing(true);
     setLocalPath(currentPath);
   };
@@ -116,7 +119,7 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
             <Paragraph tagName="p" variant="p1" text={`Local Path: ${currentPath}`} />
           )}
         </div>
-        <div className="edit-icon">
+        <div className={`edit-icon${isValidated ? ' edit-icon--disabled' : ''}`}>
           <Icon icon="EditSmallActive" size="small" onClick={handleEditFile} />
         </div>
       </div>

--- a/ui/src/components/LegacyCms/legacyCms.scss
+++ b/ui/src/components/LegacyCms/legacyCms.scss
@@ -166,7 +166,7 @@
   line-clamp: 2;
   -webkit-box-orient: vertical;
   width: 540px;
-  gap: 10px;
+  gap: 5px;
 
   .file-path-text {
     flex: 1;
@@ -184,10 +184,16 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 5px;
-    
+    padding-right: 10px;
+
     &:hover {
       opacity: 0.7;
+    }
+
+    &--disabled {
+      cursor: not-allowed;
+      opacity: 0.4;
+      pointer-events: none;
     }
   }
 }

--- a/ui/src/components/Stepper/HorizontalStepper/HorizontalStepper.tsx
+++ b/ui/src/components/Stepper/HorizontalStepper/HorizontalStepper.tsx
@@ -105,7 +105,10 @@ const HorizontalStepper = forwardRef(
       if (!Number.isNaN(stepIndex) && stepIndex >= 0 && stepIndex < steps?.length) {
         !newMigrationDataRef?.current?.isprojectMapped && setShowStep(stepIndex);
         setStepsCompleted((prev) => {
-          const updatedStepsCompleted = [...prev];
+          // Drop any completed steps at or beyond the current step so a restart
+          // (navigating back to an earlier step) un-fills the connectors ahead of it.
+          // Steps before the current one remain completed.
+          const updatedStepsCompleted = prev?.filter((i) => i < stepIndex);
           if (
             stepIndex === 4 &&
             (props?.projectData?.isMigrationCompleted ||

--- a/ui/src/pages/Migration/index.tsx
+++ b/ui/src/pages/Migration/index.tsx
@@ -471,6 +471,7 @@ const Migration = () => {
       isprojectMapped: false,
       project_current_step: projectData?.current_step,
       isContentMapperGenerated: projectData?.content_mapper?.length > 0,
+      iteration: projectData?.iteration ?? 1,
     };
 
     dispatch(updateNewMigrationData(projectMapper));


### PR DESCRIPTION
## 🔗 Jira Ticket

. [CMG-985](https://contentstack.atlassian.net/browse/CMG-985) 
· [CMG-986](https://contentstack.atlassian.net/browse/CMG-986) 
· [CMG-987](https://contentstack.atlassian.net/browse/CMG-987) 
· [CMG-988](https://contentstack.atlassian.net/browse/CMG-988) 
· [CMG-989](https://contentstack.atlassian.net/browse/CMG-989)

---

## 📋 PR Type

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

- **Restart flow:** Preserve the selected CMS version and file format on restart instead of resetting to `DEFAULT_CMS_TYPE`. `LoadSelectCms` was wiping `selectedCms.cms_id` to empty when multiple versions exist (e.g. Sitecore v8/v9/v10), which made the legacy-CMS step look incomplete and triggered a false "Please complete Imported File step" warning on Save & Continue.
- **CMS card:** Fixed the radio `checked` to compare on `cms_id` instead of the always-`undefined` `id`, so the selected version card reflects actual state.
- **Entry Mapper:** Read `iteration` from the project DB response into Redux so the Content Mapper renders the Entry Mapper (iteration > 1) instead of the content-type mapper after switching projects.
- **Progress bar:** Reset completed steps at/beyond the current step on restart so the horizontal stepper un-fills instead of staying filled to the end.
- **Edit icon:** Disable the file-path edit icon once the file is validated (greyed out, not-allowed cursor, pointer-events none).
- **CSS:** Added padding to the error container so the red border no longer overlaps content; vertically centered the row-select checkbox in the entry-mapper table.

### Why?

After restarting a migration, the selected version was being lost in Redux, blocking Save & Continue with a misleading error. Separately, the wrong mapper rendered on revisited projects, the progress bar didn't reset, and a few UI alignment/overlap issues needed cleanup.

---

## 🧩 Affected Areas

- [ ] `api` — Node.js backend
- [x] `ui` — React frontend
- [ ] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

1. Open a project with a Sitecore version selected (e.g. v9), complete and run the migration.
2. Restart the migration, then go to step 1 (Select Legacy CMS).
3. Without changing the version, click **Save and Continue**.

**Expected result:** The previously selected version stays checked, no "Please complete Imported File step" warning appears, and the flow proceeds. Also verify: switching to a project with iteration > 1 renders the Entry Mapper; the progress bar resets after restart; the edit icon is disabled once a file is validated.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

- N/A

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `feature/`, `bugfix/`, or `hotfix/` + 5–30 lowercase chars
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added — N/A
- [x] No sensitive credentials or secrets committed
- [x] Existing tests pass locally (`npm test`)
- [ ] New tests written (or not applicable — explain why) — N/A, UI/state bug fixes verified manually
- [ ] `README.md` / docs updated if behaviour changed — N/A
- [x] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

Core fix is in `LoadSelectCms.filterCMSData` — it now keeps an already-selected version if it's still valid among the filtered cards, only falling back to default when nothing is selected. All changes are frontend-only (`ui`).

