### PR TITLE
feat: support editing Drupal MySQL connection details

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -166,6 +166,17 @@
         "lru-cache": "^10.4.3"
       }
     },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+      "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -336,30 +347,30 @@
       }
     },
     "node_modules/@contentstack/cli": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli/-/cli-1.62.0.tgz",
-      "integrity": "sha512-k86KUM1+Mp2fTjwy8Ku3QjhcdTPwnl3w5dbQKZ64jo/HlEQ6USUAA7/C/v6VkyS4+8vNOVyuV+h7EFtAD2gGxg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli/-/cli-1.63.0.tgz",
+      "integrity": "sha512-8mMVRguUrcBDd971DAMTke06I06WKDl91OYLhg51J5C9Do6+k58JuuZUzQuT5bhgDSfPGCkNzRfGUIlQgLX4RQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-audit": "~1.19.3",
-        "@contentstack/cli-auth": "~1.8.2",
-        "@contentstack/cli-cm-bootstrap": "~1.19.3",
-        "@contentstack/cli-cm-branches": "~1.8.1",
-        "@contentstack/cli-cm-bulk-publish": "~1.11.3",
-        "@contentstack/cli-cm-clone": "~1.21.4",
-        "@contentstack/cli-cm-export": "~1.25.0",
-        "@contentstack/cli-cm-export-to-csv": "~1.12.2",
-        "@contentstack/cli-cm-import": "~1.33.0",
-        "@contentstack/cli-cm-import-setup": "~1.8.3",
-        "@contentstack/cli-cm-migrate-rte": "~1.6.4",
-        "@contentstack/cli-cm-seed": "~1.15.3",
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-config": "~1.20.3",
-        "@contentstack/cli-launch": "^1.9.8",
-        "@contentstack/cli-migration": "~1.12.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@contentstack/cli-variants": "~1.5.0",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-audit": "~1.19.4",
+        "@contentstack/cli-auth": "~1.8.3",
+        "@contentstack/cli-cm-bootstrap": "~1.19.5",
+        "@contentstack/cli-cm-branches": "~1.8.2",
+        "@contentstack/cli-cm-bulk-publish": "~1.12.0",
+        "@contentstack/cli-cm-clone": "~1.21.6",
+        "@contentstack/cli-cm-export": "~1.25.1",
+        "@contentstack/cli-cm-export-to-csv": "~1.12.3",
+        "@contentstack/cli-cm-import": "~1.33.2",
+        "@contentstack/cli-cm-import-setup": "~1.8.4",
+        "@contentstack/cli-cm-migrate-rte": "~1.7.0",
+        "@contentstack/cli-cm-seed": "~1.15.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-config": "~1.20.4",
+        "@contentstack/cli-launch": "^1.10.0",
+        "@contentstack/cli-migration": "~1.12.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@contentstack/cli-variants": "~1.5.1",
+        "@oclif/core": "^4.11.4",
         "@oclif/plugin-help": "^6.2.28",
         "@oclif/plugin-not-found": "^3.2.53",
         "@oclif/plugin-plugins": "^5.4.54",
@@ -375,14 +386,14 @@
       }
     },
     "node_modules/@contentstack/cli-audit": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-audit/-/cli-audit-1.19.3.tgz",
-      "integrity": "sha512-IPLB6vR2c8yBW6Q6jGEtFSTLI/9aBNNIzpkp2WVqRMmE87c2ALSreFuBgqn4I1lWfxEnBU1+BqKcDnDN70miQg==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-audit/-/cli-audit-1.19.4.tgz",
+      "integrity": "sha512-EnaBkjRSAMZZSOOxGDQ6NY2c6guEJjmMhPGIlrD11eq/FcbXk/iW5K6pj+5ws/+3LCDXhpJc5Uf0zLo4iOCThQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "chalk": "^4.1.2",
         "fast-csv": "^4.3.6",
         "fs-extra": "^11.3.0",
@@ -397,14 +408,14 @@
       }
     },
     "node_modules/@contentstack/cli-auth": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-auth/-/cli-auth-1.8.2.tgz",
-      "integrity": "sha512-S1/KQ+ccUFeVaNzkPkvmg02gdc1dAma+z9CVhgMyyGWQBr6MpMmTBd+9Yq9GGvTTETP9PA2H2KlJDMXqrc9+4A==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-auth/-/cli-auth-1.8.3.tgz",
+      "integrity": "sha512-7umjjchKUDJslklQo+0Yq+BdS2vJw3zofejkQo7WIvZ/ByiugxSe2JHWbRbsat+NE8eWf1NxaZjXdwtRGkXQEg==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "otplib": "^12.0.1"
       },
       "engines": {
@@ -412,16 +423,16 @@
       }
     },
     "node_modules/@contentstack/cli-cm-bootstrap": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-bootstrap/-/cli-cm-bootstrap-1.19.3.tgz",
-      "integrity": "sha512-R0pLwtp6MX3WanOUxy6lWXjRrTgqL0E0DMzarFQ9+BnnE4hhcVBqppIUGXIeBN2e11XiHMUv3iKjQlsPnOpZZg==",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-bootstrap/-/cli-cm-bootstrap-1.19.5.tgz",
+      "integrity": "sha512-wbkRuhqPlwvchBJ4xsGE4E7DuCil10k0kTtiepDLdIMSrjIuhehHGNSyYHwuVL0NT/di3SfTFbejXij3t9z4sw==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-cm-seed": "~1.15.3",
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-config": "~1.20.3",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-cm-seed": "~1.15.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-config": "~1.20.4",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "inquirer": "8.2.7",
         "mkdirp": "^2.1.6",
         "tar": "^7.5.11"
@@ -446,14 +457,14 @@
       }
     },
     "node_modules/@contentstack/cli-cm-branches": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-branches/-/cli-cm-branches-1.8.1.tgz",
-      "integrity": "sha512-8FFOV96cG3DQVckfiuiTv6EjvuqNctwBAvYJFweLAupIYH3t54dosfcvbBYDssAEbyquS2a61AcgzYdayp90hQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-branches/-/cli-cm-branches-1.8.2.tgz",
+      "integrity": "sha512-iGOg+iwAY6J+pp8HQsjpUA7hAc2kHSgKcXHg0sfXBiGeRwPbTBU2l8L008cjt2DwASvDsJwQRXVJYp4m+7HIeg==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "chalk": "^4.1.2",
         "just-diff": "^6.0.2",
         "lodash": "^4.18.1"
@@ -463,15 +474,15 @@
       }
     },
     "node_modules/@contentstack/cli-cm-bulk-publish": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-bulk-publish/-/cli-cm-bulk-publish-1.11.3.tgz",
-      "integrity": "sha512-XF9lWI/2irHjhECPhwDmuXH+U1PEsMhAQR5XccVb4aBV9ZBDgRNE/zZu9wbqwg1Yo8ABjTYBh5YmaSJUf+Cang==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-bulk-publish/-/cli-cm-bulk-publish-1.12.0.tgz",
+      "integrity": "sha512-v5XlYnzhWdshcCqmN161uT48WqiQ0wlIL+mRxiu/q4K862/lPi1d1xNrNhCLAF/pUFkUUyAymkWJUyktCUh5TA==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-config": "~1.20.3",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-config": "~1.20.4",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "chalk": "^4.1.2",
         "dotenv": "^16.6.1",
         "inquirer": "8.2.7",
@@ -483,17 +494,17 @@
       }
     },
     "node_modules/@contentstack/cli-cm-clone": {
-      "version": "1.21.4",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-clone/-/cli-cm-clone-1.21.4.tgz",
-      "integrity": "sha512-avViGfWCg6o471Nb2ZNxLalgFmHu9Fmq3P5zkiJmz+X0iNIS406gRcD2PaxLs9YtVmKlpDwxpzIqyGnm1Ee4cg==",
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-clone/-/cli-cm-clone-1.21.6.tgz",
+      "integrity": "sha512-XhCSGKVCiRr4XAAAKbWhrGZPHqXiz5Bl7u6ECw5JTp4ReneEexDghxrhbsw17wHyempOedIDLux0K7bITv6FkA==",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
-        "@contentstack/cli-cm-export": "~1.25.0",
-        "@contentstack/cli-cm-import": "~1.33.0",
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-cm-export": "~1.25.1",
+        "@contentstack/cli-cm-import": "~1.33.2",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "chalk": "^4.1.2",
         "inquirer": "8.2.7",
         "lodash": "^4.18.1",
@@ -507,15 +518,15 @@
       }
     },
     "node_modules/@contentstack/cli-cm-export": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-export/-/cli-cm-export-1.25.0.tgz",
-      "integrity": "sha512-T85X1vmjkV0sgUYRlpvUMesCHLsBxjQjIwufZ0bNd0Qyd5s3I7LaFtKm08WqnQixQZFuWsxz8NB6BGTrTaF+uA==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-export/-/cli-cm-export-1.25.1.tgz",
+      "integrity": "sha512-MiXM4JiX9p5Yc7T+zWE2kTGVwCXNXUYYdNbKMvXZ1AkEl4AswQbFih5QIva8NZo/1g3OSzbEMRBkXHg5XkqtQg==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@contentstack/cli-variants": "~1.5.0",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@contentstack/cli-variants": "~1.5.1",
+        "@oclif/core": "^4.11.4",
         "async": "^3.2.6",
         "big-json": "^3.2.0",
         "bluebird": "^3.7.2",
@@ -532,14 +543,14 @@
       }
     },
     "node_modules/@contentstack/cli-cm-export-to-csv": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-export-to-csv/-/cli-cm-export-to-csv-1.12.2.tgz",
-      "integrity": "sha512-T7kb1IglD1HXkw1wHRFEO6PCRMNasW9WIbog03jD2/Q3s3BAU7v8/AyF6rt5BMio6J+HmMj+ef0DaORm+oT2qg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-export-to-csv/-/cli-cm-export-to-csv-1.12.3.tgz",
+      "integrity": "sha512-DnGA73AB13fG0vPtvhnK+qx8nZnJZZt8X/bowj/IB7nbHE2RYmSON0zZiNDqfBOz5baFT0dZcEhr+s3hkd8y0Q==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "fast-csv": "^4.3.6",
         "inquirer": "8.2.7",
         "inquirer-checkbox-plus-prompt": "1.4.2"
@@ -561,16 +572,16 @@
       }
     },
     "node_modules/@contentstack/cli-cm-import": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-import/-/cli-cm-import-1.33.0.tgz",
-      "integrity": "sha512-qpgQXqL4fNdr3V8ZD2A1eUYYiOL6L03Qglx0GJ/ZCz9epkvz+tdpE9EJd05iMqfDF3zJ1xJFsu2nTwKJ7KOYEg==",
+      "version": "1.33.2",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-import/-/cli-cm-import-1.33.2.tgz",
+      "integrity": "sha512-Ns6Ma6MRrQoggrnMwGoFNEzprefwrZeu7kD1dc6e6/+qiSstujVf+lvHUB4zEcNCrLba58363Om0FW6I3vvgCA==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-audit": "~1.19.3",
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@contentstack/cli-variants": "~1.5.0",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-audit": "~1.19.4",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@contentstack/cli-variants": "~1.5.1",
+        "@oclif/core": "^4.11.4",
         "big-json": "^3.2.0",
         "bluebird": "^3.7.2",
         "chalk": "^4.1.2",
@@ -588,14 +599,14 @@
       }
     },
     "node_modules/@contentstack/cli-cm-import-setup": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-import-setup/-/cli-cm-import-setup-1.8.3.tgz",
-      "integrity": "sha512-CaZNXbyTuj91i17FsK5xMH2JLHxivq6v15lv3RM90LQbypsXLbHsgNJS+LxZ037U86wPe6+4GUirxEHdv8hxvA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-import-setup/-/cli-cm-import-setup-1.8.4.tgz",
+      "integrity": "sha512-Nisd9nLKz/Fy2+r9vfQFG3mi0DiuavDv6cNlm8bwyhRPDVlf/lli85fZZuIZH34JjzK0rn0Ps+huRSXhfcmh9Q==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "big-json": "^3.2.0",
         "chalk": "^4.1.2",
         "fs-extra": "^11.3.0",
@@ -633,79 +644,25 @@
       }
     },
     "node_modules/@contentstack/cli-cm-migrate-rte": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-migrate-rte/-/cli-cm-migrate-rte-1.6.4.tgz",
-      "integrity": "sha512-TKswWWtq+DmUDXv+Fx88vxBAhS3kqfBoRXIOGJQNIdpQzHzaLxiCyOdmcCFyK1YhYDWzU19ad/s0GLBlv0D8fg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-migrate-rte/-/cli-cm-migrate-rte-1.7.0.tgz",
+      "integrity": "sha512-ldBH/mgSLNFr+ARE/UyqmGipK+FCQ45L5viLD+pEpFb9nXxva6v8p7VNPvpQKqob5rPKEyKi5IYU+L4OBRxgeA==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.7.2",
-        "@contentstack/cli-utilities": "~1.17.0",
+        "@contentstack/cli-command": "1.8.3",
+        "@contentstack/cli-utilities": "1.18.4",
         "@contentstack/json-rte-serializer": "~2.1.0",
-        "@oclif/core": "^4.3.0",
-        "@oclif/plugin-help": "^6.2.28",
+        "@oclif/core": "^4.11.4",
+        "@oclif/plugin-help": "^6.2.37",
         "chalk": "^4.1.2",
         "collapse-whitespace": "^1.1.7",
-        "jsdom": "^20.0.3",
+        "jsdom": "^23.2.0",
         "jsonschema": "^1.5.0",
-        "lodash": "^4.17.21",
-        "nock": "^13.5.6",
-        "omit-deep-lodash": "^1.1.7",
-        "sinon": "^21.0.1"
+        "lodash": "^4.18.1",
+        "omit-deep-lodash": "^1.1.7"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/@contentstack/cli-command": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-command/-/cli-command-1.7.2.tgz",
-      "integrity": "sha512-dtXc3gIcnivfLegADy5/PZb+1x/esZ65H2E1CjO/pg50UC8Vy1U+U0ozS0hJZTFoaVjeG+1VJRoxf5MrtUGnNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentstack/cli-utilities": "~1.17.0",
-        "@oclif/core": "^4.3.0",
-        "@oclif/plugin-help": "^6.2.28",
-        "contentstack": "^3.25.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/@contentstack/cli-utilities": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-utilities/-/cli-utilities-1.17.4.tgz",
-      "integrity": "sha512-45Ujy0lNtQiU0FhZrtfGEfte4kjy3tlOnlVz6REH+cW/y1Dgg1nMh+YVgygbOh+6b8PkvTYVlEvb15UxRarNiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentstack/management": "~1.27.5",
-        "@contentstack/marketplace-sdk": "^1.5.0",
-        "@oclif/core": "^4.3.0",
-        "axios": "^1.13.5",
-        "chalk": "^4.1.2",
-        "cli-cursor": "^3.1.0",
-        "cli-progress": "^3.12.0",
-        "cli-table": "^0.3.11",
-        "conf": "^10.2.0",
-        "dotenv": "^16.6.1",
-        "figures": "^3.2.0",
-        "inquirer": "8.2.7",
-        "inquirer-search-checkbox": "^1.0.0",
-        "inquirer-search-list": "^1.2.6",
-        "js-yaml": "^4.1.1",
-        "klona": "^2.0.6",
-        "lodash": "^4.17.23",
-        "mkdirp": "^1.0.4",
-        "open": "^8.4.2",
-        "ora": "^5.4.1",
-        "papaparse": "^5.5.3",
-        "recheck": "~4.4.5",
-        "rxjs": "^6.6.7",
-        "traverse": "^0.6.11",
-        "tty-table": "^4.2.3",
-        "unique-string": "^2.0.0",
-        "uuid": "^9.0.1",
-        "winston": "^3.17.0",
-        "xdg-basedir": "^4.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/@contentstack/json-rte-serializer": {
@@ -728,7 +685,53 @@
         "uuid": "^8.3.2"
       }
     },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/@contentstack/json-rte-serializer/node_modules/uuid": {
+    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/jsdom": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "license": "MIT"
+    },
+    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
@@ -738,253 +741,19 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "license": "MIT",
-      "dependencies": {
-        "cssom": "~0.3.6"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "license": "MIT"
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/jsdom": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@contentstack/cli-cm-migrate-rte/node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@contentstack/cli-cm-seed": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-seed/-/cli-cm-seed-1.15.3.tgz",
-      "integrity": "sha512-HfeBx5GkTLdDGgtBV9G66dP1ZBKqFe0JhGzkH/3wHgJmEON93kKhk0xLLLNeIxfy6EhiBj+LwAuxLZvbhBTU8w==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-cm-seed/-/cli-cm-seed-1.15.5.tgz",
+      "integrity": "sha512-a1g/V5csmge0/vrTBiGv7sTUC8aciZZiujFi+N7mkbTWyUdUxXZLofTiHGZJpFi6nLCuNTZTxuu7LMGdcOI+Og==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-cm-import": "~1.33.0",
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
+        "@contentstack/cli-cm-import": "~1.33.2",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
         "inquirer": "8.2.7",
         "mkdirp": "^1.0.4",
         "tar": "^7.5.11",
-        "tmp": "^0.2.5"
+        "tmp": "^0.2.7"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1003,13 +772,13 @@
       }
     },
     "node_modules/@contentstack/cli-command": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-command/-/cli-command-1.8.2.tgz",
-      "integrity": "sha512-vwadTZkJjfS3Cay9r6Rno01tYxhkMeyfB/jAvQmNmvrdfxnpG0kxwmZItjaQI+aq8jnuNitBmivGCT+EqgMVlQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-command/-/cli-command-1.8.3.tgz",
+      "integrity": "sha512-UYnIkO4B3k/qhz4snI6UFVkKcbseyXXreXzKM4T8d/fzMl0Ra6cNGeIMiGgo1RZ2rYlNRfZ2HdfhsPw6e3hlHA==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "contentstack": "^3.27.0"
       },
       "engines": {
@@ -1017,24 +786,24 @@
       }
     },
     "node_modules/@contentstack/cli-config": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-config/-/cli-config-1.20.3.tgz",
-      "integrity": "sha512-QXZpMb+TAbpze1oZN2vfc2T3QiD23YV2bquTBv8aDqYrN4YxvR/7Cz81qhE2GfPcr2B+Psdd8H7ChY33UkQ/vg==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-config/-/cli-config-1.20.4.tgz",
+      "integrity": "sha512-4afOEI8Iekr3CIj5cc+4bTDWZ8i0972oylFi5XiQtluQjwmw9fO1Es5RVhu8mw6EduktyYyzmwF/WJSG/EP6OQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-command": "~1.8.2",
-        "@contentstack/cli-utilities": "~1.18.3",
+        "@contentstack/cli-command": "~1.8.3",
+        "@contentstack/cli-utilities": "~1.18.4",
         "@contentstack/utils": "~1.9.1",
-        "@oclif/core": "^4.8.3"
+        "@oclif/core": "^4.11.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@contentstack/cli-launch": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-launch/-/cli-launch-1.9.9.tgz",
-      "integrity": "sha512-RwfB4CR4aWqyJX+8Bk8vdjDdyUZTs1LH0ny4A91FkdBK7lDaTOyIIwm2Fha5txw4Og/NVK1XxvaC1wGI5FCbYA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-launch/-/cli-launch-1.10.1.tgz",
+      "integrity": "sha512-FaEvN35aOlPgEJDwUqmh7YMJakctL08dn5cU9wM9z6e3J8DXih2D1VnrJGAS76pDMTefD8RYbz6cS5NqDkea3Q==",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.14.0",
@@ -1069,14 +838,14 @@
       }
     },
     "node_modules/@contentstack/cli-migration": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-migration/-/cli-migration-1.12.2.tgz",
-      "integrity": "sha512-QaiRCs6NdiGnT4E8H8497A1TH2VHs/aMNMKZyi3LmnE9a+YdItU+QOVQBPKRXP7vw0vkAGcfwgs+f9O4TxNNWA==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-migration/-/cli-migration-1.12.3.tgz",
+      "integrity": "sha512-xOh5WjZHy0xqTRJKvf1Vv0EEAqFldcJlyBFnxVWkuSIu0bE1dJb1cFYf9/2cGXxRvApY5DgDdNq6sYgqk8BBUQ==",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.8.2",
         "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@oclif/core": "^4.11.4",
         "async": "^3.2.6",
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
@@ -1090,15 +859,15 @@
       }
     },
     "node_modules/@contentstack/cli-utilities": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-utilities/-/cli-utilities-1.18.3.tgz",
-      "integrity": "sha512-qrkfODXP+SSVNQyoGe2OQ73VmORUcSjqhk2MafothAZiac7vNsyZ4E/rMvskDmJjH6azjjQI99/Ejao78YrCyw==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-utilities/-/cli-utilities-1.18.4.tgz",
+      "integrity": "sha512-6Q+zge0WP8e5FXRXH1mmsbzAy3xHluUsDdUHO2w8/1w5wyG1rifCi2YcP3GdZJPAoHTq21X9fL9i2KCPZ1GsXg==",
       "license": "MIT",
       "dependencies": {
         "@contentstack/management": "~1.30.1",
         "@contentstack/marketplace-sdk": "^1.5.1",
-        "@oclif/core": "^4.10.5",
-        "axios": "^1.15.2",
+        "@oclif/core": "^4.11.4",
+        "axios": "^1.16.1",
         "chalk": "^4.1.2",
         "cli-cursor": "^3.1.0",
         "cli-progress": "^3.12.0",
@@ -1189,13 +958,13 @@
       }
     },
     "node_modules/@contentstack/cli-variants": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-variants/-/cli-variants-1.5.0.tgz",
-      "integrity": "sha512-b8K3ak2fRjZBiMw24Q56HosNEZfUqGDvWuI80AHUrvTd94LvAqqnMAR+rb+MG7xqUIX2NHey3ey2qApppDDPTw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-variants/-/cli-variants-1.5.1.tgz",
+      "integrity": "sha512-uUHj6jRnIdGCpfPKTZ0PXhrp+6TZFSrocYTdqrnFGAiwJ+Az9K5FWo9xIeX3Jf4EACbwcq2OfGbjsD/1t2DKfQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-utilities": "~1.18.3",
-        "@oclif/core": "^4.10.5",
+        "@contentstack/cli-utilities": "~1.18.4",
+        "@oclif/core": "^4.11.4",
         "lodash": "^4.18.1",
         "mkdirp": "^1.0.4",
         "winston": "^3.19.0"
@@ -1214,13 +983,13 @@
       }
     },
     "node_modules/@contentstack/json-rte-serializer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@contentstack/json-rte-serializer/-/json-rte-serializer-3.0.5.tgz",
-      "integrity": "sha512-WWntS1vO8Hzacf5YU14w1my7oivcwFs9l0gqaq2r5tPJ/5bWtgIW8zOVO5teMX63pMHWCUy+69FmD/xMoGFIsw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@contentstack/json-rte-serializer/-/json-rte-serializer-3.1.0.tgz",
+      "integrity": "sha512-FEnc/k3n91BDkZc7wn0gY/5AmDoXqR91LQQ40oWwWXLNyPoKsW2dvk+0Jk1gsiuNOY4t49qsQ4cNcEvR+VKGew==",
       "license": "MIT",
       "dependencies": {
         "array-flat-polyfill": "^1.0.1",
-        "lodash": "^4.17.23",
+        "lodash": "4.18.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.flatten": "^4.4.0",
         "lodash.isempty": "^4.4.0",
@@ -1230,53 +999,20 @@
         "lodash.isundefined": "^3.0.1",
         "lodash.kebabcase": "^4.1.1",
         "slate": "^0.103.0",
-        "uuid": "^8.3.2"
+        "uuid": "^11.1.1"
       }
     },
     "node_modules/@contentstack/json-rte-serializer/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@contentstack/management": {
-      "version": "1.27.6",
-      "resolved": "https://registry.npmjs.org/@contentstack/management/-/management-1.27.6.tgz",
-      "integrity": "sha512-92h8YzKZ2EDzMogf0fmBHapCjVpzHkDBIj0Eb/MhPFIhlybDlAZhcM/di6zwgicEJj5UjTJ+ETXXQMEJZouDew==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentstack/utils": "^1.7.0",
-        "assert": "^2.1.0",
-        "axios": "^1.13.5",
-        "buffer": "^6.0.3",
-        "form-data": "^4.0.5",
-        "husky": "^9.1.7",
-        "lodash": "^4.17.23",
-        "otplib": "^12.0.1",
-        "qs": "^6.15.0",
-        "stream-browserify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@contentstack/management/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@contentstack/marketplace-sdk": {
@@ -2728,9 +2464,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.2.tgz",
-      "integrity": "sha512-LWDalCgy+hYyAkLa9sMIXMXk6ws5RzQhVnkmfXtVIIyEEYigbXQ/9/x+s76p53MiXxNc6SJB7lfwkPF+SdzfMQ==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -2744,10 +2480,10 @@
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
         "minimatch": "^10.2.5",
-        "semver": "^7.8.0",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.16",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -2757,9 +2493,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.44",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.44.tgz",
-      "integrity": "sha512-x03Se2LtlOOlGfTuuubt5C4Z8NHeR4zKXtVnfycuLU+2VOMu2WpsGy9nbs3nYuInuvsIY1BizjVaTjUz060Sig==",
+      "version": "6.2.50",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.50.tgz",
+      "integrity": "sha512-rNCG4hUm+kPXFbhJfAVk/fZ3OdWJYwBDASlyX8CqOLP0MssjIGl7iEgfZz7TMuZFa+KucupKU5NRSc0KWfPTQA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -3270,9 +3006,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -3292,9 +3028,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
       "cpu": [
         "arm"
       ],
@@ -3305,9 +3041,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
       "cpu": [
         "arm64"
       ],
@@ -3318,9 +3054,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
       "cpu": [
         "arm64"
       ],
@@ -3331,9 +3067,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
       "cpu": [
         "x64"
       ],
@@ -3344,9 +3080,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
       "cpu": [
         "arm64"
       ],
@@ -3357,9 +3093,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
       "cpu": [
         "x64"
       ],
@@ -3370,9 +3106,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
       "cpu": [
         "arm"
       ],
@@ -3383,9 +3119,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
       "cpu": [
         "arm"
       ],
@@ -3396,9 +3132,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
       "cpu": [
         "arm64"
       ],
@@ -3409,9 +3145,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
       "cpu": [
         "arm64"
       ],
@@ -3422,9 +3158,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
       "cpu": [
         "loong64"
       ],
@@ -3435,9 +3171,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
       "cpu": [
         "loong64"
       ],
@@ -3448,9 +3184,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
       "cpu": [
         "ppc64"
       ],
@@ -3461,9 +3197,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
       "cpu": [
         "ppc64"
       ],
@@ -3474,9 +3210,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
       "cpu": [
         "riscv64"
       ],
@@ -3487,9 +3223,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3500,9 +3236,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
       "cpu": [
         "s390x"
       ],
@@ -3513,9 +3249,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
       "cpu": [
         "x64"
       ],
@@ -3526,9 +3262,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
       "cpu": [
         "x64"
       ],
@@ -3539,9 +3275,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
       "cpu": [
         "x64"
       ],
@@ -3552,9 +3288,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
       "cpu": [
         "arm64"
       ],
@@ -3565,9 +3301,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
       "cpu": [
         "arm64"
       ],
@@ -3578,9 +3314,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
       "cpu": [
         "ia32"
       ],
@@ -3591,9 +3327,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
       "cpu": [
         "x64"
       ],
@@ -3604,9 +3340,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
       "cpu": [
         "x64"
       ],
@@ -3634,43 +3370,6 @@
         "zen-observable": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "15.3.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
-      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
-      "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@so-ric/colorspace": {
@@ -3730,15 +3429,6 @@
       "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
-      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -3805,9 +3495,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -4982,13 +4672,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5006,22 +4689,13 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.1.0",
-        "acorn-walk": "^8.0.2"
       }
     },
     "node_modules/acorn-jsx": {
@@ -5032,18 +4706,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/adm-zip": {
@@ -5480,6 +5142,15 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big-json": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big-json/-/big-json-3.2.0.tgz",
@@ -5554,9 +5225,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -5567,7 +5238,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -5611,9 +5282,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6495,6 +6166,19 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -6506,12 +6190,6 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
-    },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -6905,19 +6583,6 @@
       ],
       "license": "BSD-2-Clause"
     },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "license": "MIT",
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
@@ -7125,9 +6790,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
-      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -7139,7 +6804,7 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -7155,9 +6820,9 @@
       }
     },
     "node_modules/engine.io/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -7437,37 +7102,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
@@ -7642,6 +7276,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -7657,6 +7292,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7682,14 +7318,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -7708,7 +7344,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -8671,9 +8307,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
-      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -10413,6 +10049,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -10439,12 +10076,6 @@
       "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-2.0.4.tgz",
       "integrity": "sha512-gIPoa6K5w6j/RnQ3fOtmvICKNJGViI83A7dnTIL+0QJ/1GKuNvCPFvbFWxt0agruF4iGgDFJvge4Gua4ZoiggQ==",
       "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -11667,6 +11298,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -11943,9 +11580,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -11986,20 +11623,6 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
       }
     },
     "node_modules/node-fetch": {
@@ -14576,9 +14199,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -14596,7 +14219,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -14781,15 +14404,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -14834,9 +14448,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -15348,12 +14962,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -15363,31 +14977,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.4",
-        "@rollup/rollup-android-arm64": "4.60.4",
-        "@rollup/rollup-darwin-arm64": "4.60.4",
-        "@rollup/rollup-darwin-x64": "4.60.4",
-        "@rollup/rollup-freebsd-arm64": "4.60.4",
-        "@rollup/rollup-freebsd-x64": "4.60.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-musl": "4.60.4",
-        "@rollup/rollup-openbsd-x64": "4.60.4",
-        "@rollup/rollup-openharmony-arm64": "4.60.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -15585,9 +15199,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15834,31 +15448,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sinon": {
-      "version": "21.1.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.1.2.tgz",
-      "integrity": "sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.3.2",
-        "@sinonjs/samsam": "^10.0.2",
-        "diff": "^8.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16057,19 +15646,19 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       }
     },
     "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -16114,7 +15703,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -16464,9 +16052,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -16489,6 +16077,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/thirty-two": {
@@ -16572,9 +16161,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -16746,15 +16335,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -17597,9 +17177,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3424,9 +3424,9 @@
       "integrity": "sha512-4E+pnt4v8HSEEH3Dwe2Bcu8TIbdReez7b5Qjs11dJIdbGFaNSobDgphWxy9NtjYB9ZsZd7DzByDbeXy4DvYz5Q=="
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4227,35 +4227,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3",
+        "ws": "~8.20.1",
         "xmlhttprequest-ssl": "~2.1.1"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/engine.io-parser": {
@@ -6083,12 +6064,10 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "engines": {
-        "node": ">=14"
-      }
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -9639,6 +9618,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -39,7 +39,7 @@ import { ItemStatusMapProp } from '@contentstack/venus-components/build/componen
 // Styles and Assets
 import './index.scss';
 
-const EntryMapper = ({selectedContentTypeId, tableHeight}: {selectedContentTypeId: ContentType | null, tableHeight: number}) => {
+const EntryMapper = ({selectedContentTypeId, tableHeight, onEntrySelectionChange}: {selectedContentTypeId: ContentType | null, tableHeight: number, onEntrySelectionChange?: (contentTypeId: string, hasSelection: boolean) => void}) => {
   // Redux State
   const dispatch = useDispatch();
 
@@ -173,6 +173,12 @@ const EntryMapper = ({selectedContentTypeId, tableHeight}: {selectedContentTypeI
       setPersistedRowIds(initialSelected);
       setTotalCounts(validTableData?.length);
       setInitialRowSelectedData(validTableData?.filter((item: EntryMapperType) => !item?.isUpdate))
+
+      // Reflect any pre-existing entry selections on the content type icon (green when present)
+      const ctId = contentTypeId || selectedContentTypeId?.id;
+      if (ctId) {
+        onEntrySelectionChange?.(ctId, Object.keys(initialSelected ?? {}).length > 0);
+      }
      
     } catch (error) {
       console.error('fetchData -> error', error);
@@ -272,6 +278,15 @@ const EntryMapper = ({selectedContentTypeId, tableHeight}: {selectedContentTypeI
         if (status === 200) {
           setPersistedRowIds({ ...(rowIds ?? {}) });
           setLoading(false);
+
+          // Reflect the saved update on the content type icon: green (Updated) when entries
+          // remain selected after save, blue (Mapped) when all selections were cleared.
+          const ctId = selectedContentTypeId?.id || contentTypeUid;
+          if (ctId) {
+            const hasSelection = Object.values(rowIds ?? {}).some(Boolean);
+            onEntrySelectionChange?.(ctId, hasSelection);
+          }
+
           return Notification({
             notificationContent: { text: 'Entries saved successfully' },
             notificationProps: {
@@ -404,7 +419,8 @@ const EntryMapper = ({selectedContentTypeId, tableHeight}: {selectedContentTypeI
         }}
 
     />
-    <div className="mapper-footer">
+    {totalCounts > 0 && (
+      <div className="mapper-footer">
           <div>Total Entries: <strong>{totalCounts}</strong></div>
           <Button
             className="saveButton"
@@ -415,7 +431,8 @@ const EntryMapper = ({selectedContentTypeId, tableHeight}: {selectedContentTypeI
           >
             Save
           </Button>
-    </div>
+      </div>
+    )}
 
       
     </div>

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -492,6 +492,22 @@ div .table-row {
 }
 
 .entry-mapper-container {
+  // Empty state ("No Records Found"): venus renders a plain .Table__body with no height,
+  // so it collapses to just the text. Stretch the table chrome and the empty message to
+  // fill the available viewport space instead of leaving a grey gap below.
+  .TableWrapper,
+  .Table {
+    min-height: calc(100vh - 300px);
+  }
+  .no-table-data {
+    min-height: calc(100vh - 300px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
+
   .Table {
     // Force row layout alignment
     .Table__head,

--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -1129,6 +1129,18 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
   };
 
   // Method to change the content type
+  /**
+   * Reflect entry-update selection on the content type's status icon:
+   * has selected entries → 'Updated' (status '2', green); none → 'Mapped' (status '1', blue).
+   */
+  const handleEntrySelectionStatusChange = (contentTypeId: string, hasSelection: boolean) => {
+    const nextStatus = hasSelection ? '2' : '1';
+    const applyStatus = (list: ContentType[]) =>
+      list?.map?.((ct) => (ct?.id === contentTypeId ? { ...ct, status: nextStatus } : ct));
+    setContentTypes((prev) => applyStatus(prev));
+    setFilteredContentTypes((prev) => applyStatus(prev));
+  };
+
   const handleOpenContentType = (i = 0) => {
     if (isDropDownChanged) {
       setIsModalOpen(true);
@@ -3401,6 +3413,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                   <EntryMapper
                     tableHeight={tableHeight}
                     selectedContentTypeId={selectedContentType ?? null}
+                    onEntrySelectionChange={handleEntrySelectionStatusChange}
                   />
                 </div>
                 ): (
@@ -3469,18 +3482,20 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                     plural: `${totalCounts === 0 ? 'Count' : ''}`
                   }}
                 />
-                <div className="mapper-footer">
-                  <div>Total Fields: <strong>{totalCounts}</strong></div>
-                  <Button
-                    className="saveButton"
-                    onClick={handleSaveContentType}
-                    version="v2"
-                    disabled={newMigrationData?.project_current_step > 4}
-                    isLoading={isLoadingSaveButton}
-                  >
-                    Save
-                  </Button>
-                </div>
+                {totalCounts > 0 && (
+                  <div className="mapper-footer">
+                    <div>Total Fields: <strong>{totalCounts}</strong></div>
+                    <Button
+                      className="saveButton"
+                      onClick={handleSaveContentType}
+                      version="v2"
+                      disabled={newMigrationData?.project_current_step > 4}
+                      isLoading={isLoadingSaveButton}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                )}
               </div>
                 )}
             </div>

--- a/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
@@ -60,14 +60,16 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
   const dispatch = useDispatch();
   const currentPath = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath || fileDetails?.localPath || '';
 
-  // SQL editing state — mirrors the local-path edit flow but for the 3 MySQL fields
+  // SQL editing state — mirrors the local-path edit flow but for the 3 MySQL fields.
+  // Prefer the most up-to-date MySQL values from Redux over the (potentially stale) prop,
+  // so the edit inputs (which can start open when iteration > 1) don't seed/overwrite with stale data.
+  const currentMysql = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.mysql || fileDetails?.mysql;
   const [isEditingSql, setIsEditingSql] = useState((newMigrationData?.iteration > 1 && !newMigrationData?.legacy_cms?.uploadedFile?.isValidated) ? true : false);
   const [sqlDetails, setSqlDetails] = useState({
-    host: fileDetails?.mysql?.host || '',
-    database: fileDetails?.mysql?.database || '',
-    user: fileDetails?.mysql?.user || ''
+    host: currentMysql?.host || '',
+    database: currentMysql?.database || '',
+    user: currentMysql?.user || ''
   });
-  const currentMysql = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.mysql || fileDetails?.mysql;
 
   const handleEditFile = async () => {
     // Once the file is validated, editing the path is disabled

--- a/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
@@ -154,7 +154,7 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
                     width="full"
                     version="v2"
                     placeholder="Enter host"
-                    aria-label="host"
+                    aria-label="MySQL host"
                     autoFocus
                   />
                   <TextInput
@@ -163,7 +163,7 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
                     width="full"
                     version="v2"
                     placeholder="Enter database"
-                    aria-label="database"
+                    aria-label="MySQL database"
                   />
                   <TextInput
                     value={sqlDetails.user}
@@ -171,7 +171,7 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
                     width="full"
                     version="v2"
                     placeholder="Enter user"
-                    aria-label="user"
+                    aria-label="MySQL user"
                   />
                 </div>
               ) : (

--- a/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
@@ -59,13 +59,23 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
   const [localPath, setLocalPath] = useState(fileDetails?.localPath || '');
   const dispatch = useDispatch();
   const currentPath = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath || fileDetails?.localPath || '';
+
+  // SQL editing state — mirrors the local-path edit flow but for the 3 MySQL fields
+  const [isEditingSql, setIsEditingSql] = useState((newMigrationData?.iteration > 1 && !newMigrationData?.legacy_cms?.uploadedFile?.isValidated) ? true : false);
+  const [sqlDetails, setSqlDetails] = useState({
+    host: fileDetails?.mysql?.host || '',
+    database: fileDetails?.mysql?.database || '',
+    user: fileDetails?.mysql?.user || ''
+  });
+  const currentMysql = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.mysql || fileDetails?.mysql;
+
   const handleEditFile = async () => {
     // Once the file is validated, editing the path is disabled
     if (isValidated) return;
     setIsEditing(true);
     setLocalPath(currentPath);
   };
-    
+
     const handleBlur = async () => {
       setIsEditing(false);
 
@@ -84,20 +94,97 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
             }
           }
         }
-      };  
+      };
       dispatch(updateNewMigrationData(updatedMigrationData));
     };
-  
+
+  const handleEditSql = async () => {
+    // Once the connection is validated, editing the details is disabled
+    if (isValidated) return;
+    setIsEditingSql(true);
+    setSqlDetails({
+      host: currentMysql?.host || '',
+      database: currentMysql?.database || '',
+      user: currentMysql?.user || ''
+    });
+  };
+
+  const handleSqlBlur = async (e: React.FocusEvent<HTMLDivElement>) => {
+    // Only exit edit mode when focus leaves the whole group, not when moving
+    // between the host/database/user inputs.
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+
+    setIsEditingSql(false);
+
+    // Update Redux state with new MySQL details, preserving other mysql fields (e.g. port)
+    const updatedMigrationData = {
+      ...newMigrationData,
+      legacy_cms: {
+        ...newMigrationData?.legacy_cms,
+        uploadedFile: {
+          ...newMigrationData?.legacy_cms?.uploadedFile,
+          file_details: {
+            ...newMigrationData?.legacy_cms?.uploadedFile?.file_details,
+            mysql: {
+              ...newMigrationData?.legacy_cms?.uploadedFile?.file_details?.mysql,
+              host: sqlDetails.host,
+              database: sqlDetails.database,
+              user: sqlDetails.user
+            }
+          }
+        }
+      }
+    };
+    dispatch(updateNewMigrationData(updatedMigrationData));
+  };
+
 
   return (
     <div>
       { isSQL ? (
         // ✅ SQL format (from legacyCms.json allowed_file_formats): show MySQL details
         fileDetails?.mysql && (
-          <div>
-            <p className="pb-2">Host: { fileDetails?.mysql?.host }</p>
-            <p className="pb-2">Database: { fileDetails?.mysql?.database }</p>
-            <p className="pb-2">User: { fileDetails?.mysql?.user }</p>
+          <div className="file-container">
+            <div className="file-path-text">
+              {isEditingSql ? (
+                <div className="sql-edit-fields" onBlur={handleSqlBlur}>
+                  <TextInput
+                    value={sqlDetails.host}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSqlDetails((prev) => ({ ...prev, host: e.target.value }))}
+                    width="full"
+                    version="v2"
+                    placeholder="Enter host"
+                    aria-label="host"
+                    autoFocus
+                  />
+                  <TextInput
+                    value={sqlDetails.database}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSqlDetails((prev) => ({ ...prev, database: e.target.value }))}
+                    width="full"
+                    version="v2"
+                    placeholder="Enter database"
+                    aria-label="database"
+                  />
+                  <TextInput
+                    value={sqlDetails.user}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSqlDetails((prev) => ({ ...prev, user: e.target.value }))}
+                    width="full"
+                    version="v2"
+                    placeholder="Enter user"
+                    aria-label="user"
+                  />
+                </div>
+              ) : (
+                <div>
+                  <p className="pb-2">Host: { currentMysql?.host }</p>
+                  <p className="pb-2">Database: { currentMysql?.database }</p>
+                  <p className="pb-2">User: { currentMysql?.user }</p>
+                </div>
+              )}
+            </div>
+            <div className={`edit-icon${isValidated ? ' edit-icon--disabled' : ''}`}>
+              <Icon icon="EditSmallActive" size="small" onClick={handleEditSql} />
+            </div>
           </div>
         )
       ) : fileDetails?.isLocalPath ? (
@@ -210,10 +297,18 @@ const LoadUploadFile = ( props: LoadUploadFileProps ) =>
         }
       }
 
+      const validationMysql = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.mysql;
       const { data, status } = await fileValidation({
         projectId,
         affix: newMigrationData?.legacy_cms?.affix,
-        localPath: resolvedPath
+        localPath: resolvedPath,
+        mysql: validationMysql
+          ? {
+              host: validationMysql.host,
+              database: validationMysql.database,
+              user: validationMysql.user
+            }
+          : undefined
       });
 
       setProgressPercentage( 70 );

--- a/ui/src/components/LegacyCms/legacyCms.scss
+++ b/ui/src/components/LegacyCms/legacyCms.scss
@@ -172,9 +172,14 @@
     flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
-    
     .TextInput {
       width: 100%;
+    }
+
+    .sql-edit-fields {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
     }
   }
 

--- a/ui/src/components/MigrationFlowHeader/index.tsx
+++ b/ui/src/components/MigrationFlowHeader/index.tsx
@@ -109,10 +109,11 @@ const MigrationFlowHeader = ({
     newMigrationData?.project_current_step?.toString() !== params?.stepId && 
     parseInt(params?.stepId) < newMigrationData?.project_current_step;
 
-  const isExecutionStarted =
-    finalExecutionStarted ||
-    newMigrationData?.migration_execution?.migrationStarted ||
-    newMigrationData?.migration_execution?.migrationCompleted;
+  // Migration is actively running: it has been started (locally or in redux) but not yet completed.
+  // While in progress the CTA must be disabled; once completed it re-enables as "Restart Migration".
+  const isMigrationInProgress =
+    (finalExecutionStarted || newMigrationData?.migration_execution?.migrationStarted) &&
+    !newMigrationData?.migration_execution?.migrationCompleted;
 
   const destinationStackMigrated =
     params?.stepId === '5' &&
@@ -139,10 +140,11 @@ const MigrationFlowHeader = ({
         aria-label="Save and Continue"
         isLoading={isLoading || newMigrationData?.isprojectMapped}
         disabled={
-          isProjectStatusThreeAndMapperNotGenerated ?
+          isMigrationInProgress ||
+          (isProjectStatusThreeAndMapperNotGenerated ?
             isFileValidated :
-            isStep4AndNotMigrated || 
-            isStepInvalid
+            isStep4AndNotMigrated ||
+            isStepInvalid)
         }
       >
         {newMigrationData?.stepValue || 'Save and Continue'}

--- a/ui/src/services/api/service.interface.ts
+++ b/ui/src/services/api/service.interface.ts
@@ -83,4 +83,10 @@ export interface FileValidationParams {
   projectId: string;
   affix?: string;
   localPath?: string;
+  // MySQL connection details entered in the UI (drupal "Check Connection").
+  mysql?: {
+    host?: string;
+    database?: string;
+    user?: string;
+  };
 }

--- a/ui/src/services/api/upload.service.ts
+++ b/ui/src/services/api/upload.service.ts
@@ -72,7 +72,8 @@ export const uploadLocalFileToContainer = async (
 export const fileValidation = async ({
   projectId,
   affix = 'cs',
-  localPath = ''
+  localPath = '',
+  mysql
 }: FileValidationParams) => {
   try {
     const options = {
@@ -80,7 +81,11 @@ export const fileValidation = async ({
         app_token: getDataFromLocalStorage('app_token'),
         projectId: projectId,
         affix: affix,
-        file_path: localPath
+        file_path: localPath,
+        // Forwarded for drupal SQL validation; upload-api persists these into config.mysql.
+        ...(mysql?.host ? { mysql_host: mysql.host } : {}),
+        ...(mysql?.database ? { mysql_database: mysql.database } : {}),
+        ...(mysql?.user ? { mysql_user: mysql.user } : {})
       }
     };
     return await getCall(`${UPLOAD_FILE_RELATIVE_URL}validator`, options);

--- a/upload-api/migration-drupal/libs/createInitialMapper.js
+++ b/upload-api/migration-drupal/libs/createInitialMapper.js
@@ -7,6 +7,7 @@
 const fsp = require('fs/promises'); // for async file operations
 const path = require('path');
 const contentTypeMapper = require('./contentTypeMapper');
+const extractEntries = require('./extractEntries');
 
 /**
  * Internal module dependencies.

--- a/upload-api/package-lock.json
+++ b/upload-api/package-lock.json
@@ -5407,6 +5407,15 @@
         "redux": ">=4"
       }
     },
+    "node_modules/@wordpress/block-editor/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/@wordpress/block-editor/node_modules/gradient-parser": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
@@ -16543,6 +16552,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/tslib": {

--- a/upload-api/package-lock.json
+++ b/upload-api/package-lock.json
@@ -201,9 +201,9 @@
       }
     },
     "migration-aem/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -526,6 +526,16 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/@ariakit/components": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.2.tgz",
+      "integrity": "sha512-tvh2P0x1cJnoPXnmDEJwdRk3z7x6cTB8ArctcZdAUXlRg9tuwW/rJoBFJMzD5qMI9CDDlQ3Zctx58HvENw4BYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.2",
+        "@ariakit/utils": "0.1.2"
+      }
+    },
     "node_modules/@ariakit/core": {
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
@@ -549,6 +559,24 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@ariakit/react-components": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.1.2.tgz",
+      "integrity": "sha512-SM+SPMAVlOZmGAfWNBza+0k9y4mkA5/dJhDoOyhE96cbNARy665uLdwowSJl1JGuFfcZzuzAwGon7f/rYeyfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/components": "0.1.2",
+        "@ariakit/react-store": "0.1.2",
+        "@ariakit/react-utils": "0.1.2",
+        "@ariakit/store": "0.1.2",
+        "@ariakit/utils": "0.1.2",
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@ariakit/react-core": {
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
@@ -563,6 +591,49 @@
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/@ariakit/react-store": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.2.tgz",
+      "integrity": "sha512-1r1Gn0tqhnOS0LFvHNGzn5/8C5aOANO5vb0Gxh94oR/be4zwCSE2zfQjOjRfpL+BBDhOcProME2+G6UslEJxbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-utils": "0.1.2",
+        "@ariakit/store": "0.1.2",
+        "@ariakit/utils": "0.1.2",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.1.2.tgz",
+      "integrity": "sha512-Rnl6D1542Mqu80xK++oUv1JXS0PtNmKXd9nkdud5nyvySiBDTrmPqRW44/D+5GbuZrboreQuY3tPYwKL7a7onQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.2",
+        "@ariakit/utils": "0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/store": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.2.tgz",
+      "integrity": "sha512-SS7bV4+a+1q9M9i0WV6DD4P/ypRKlCvII8soo2UMe1yuaxZA/Fc0htHe+EZwjJ6TMLjHfHh2TDSnXyrjC7QImA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/utils": "0.1.2"
+      }
+    },
+    "node_modules/@ariakit/utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.2.tgz",
+      "integrity": "sha512-lBJhtBWpKjIck/9i7G8cahvaUgLsyGklI/Pjv+VtY9KTzyuzX5GpRbbLKMS/e1qLnFPS4C3CybYB70b1bVcAkw==",
+      "license": "MIT"
     },
     "node_modules/@arraypress/waveform-player": {
       "version": "1.2.1",
@@ -1387,13 +1458,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1408,11 +1479,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -1420,13 +1492,72 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -1435,48 +1566,132 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1495,29 +1710,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1525,25 +1742,26 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@base-ui/react": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
-      "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.5.0.tgz",
+      "integrity": "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.2.8",
+        "@base-ui/utils": "0.2.9",
         "@floating-ui/react-dom": "^2.1.8",
         "@floating-ui/utils": "^0.2.11",
         "use-sync-external-store": "^1.6.0"
@@ -1588,9 +1806,9 @@
       }
     },
     "node_modules/@base-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -1627,15 +1845,15 @@
       }
     },
     "node_modules/@contentstack/cli-utilities": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@contentstack/cli-utilities/-/cli-utilities-1.18.3.tgz",
-      "integrity": "sha512-qrkfODXP+SSVNQyoGe2OQ73VmORUcSjqhk2MafothAZiac7vNsyZ4E/rMvskDmJjH6azjjQI99/Ejao78YrCyw==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@contentstack/cli-utilities/-/cli-utilities-1.18.4.tgz",
+      "integrity": "sha512-6Q+zge0WP8e5FXRXH1mmsbzAy3xHluUsDdUHO2w8/1w5wyG1rifCi2YcP3GdZJPAoHTq21X9fL9i2KCPZ1GsXg==",
       "license": "MIT",
       "dependencies": {
         "@contentstack/management": "~1.30.1",
         "@contentstack/marketplace-sdk": "^1.5.1",
-        "@oclif/core": "^4.10.5",
-        "axios": "^1.15.2",
+        "@oclif/core": "^4.11.4",
+        "axios": "^1.16.1",
         "chalk": "^4.1.2",
         "cli-cursor": "^3.1.0",
         "cli-progress": "^3.12.0",
@@ -1888,9 +2106,9 @@
       }
     },
     "node_modules/@date-fns/tz": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
-      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
       "license": "MIT"
     },
     "node_modules/@date-fns/utc": {
@@ -1898,6 +2116,40 @@
       "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
       "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
@@ -1958,6 +2210,31 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "node_modules/@emotion/native": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/native/-/native-11.11.0.tgz",
+      "integrity": "sha512-t1b5bLv+o5OUNLqXlnw+LJYU10OpmYkLC/1W873Y1ohG+vObx5TT3o3Eh1okXb2KCuZTTBPgsEnU/Sl7NNkJ9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/primitives-core": "^11.11.0"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.14.0 <1"
+      }
+    },
+    "node_modules/@emotion/primitives-core": {
+      "version": "11.13.2",
+      "resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-11.13.2.tgz",
+      "integrity": "sha512-+MX60ROt1fDi5EYafhE/zs78XD4OuFUn6j0Z274wo5wVMT8sSBRx2CKPMbOUnmCcT0K5GPog+41mtkcppzkMmg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emotion/react": {
       "version": "11.14.0",
@@ -2043,448 +2320,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -2710,6 +2545,47 @@
         }
       }
     },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2719,12 +2595,34 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -2741,10 +2639,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oclif/core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.0.tgz",
-      "integrity": "sha512-nTkRMgxFlIKQIIYGvhO2JMsLSQ1aHPHblHfFgxgoBrGK8Ao/8wxc4eNOIv/+t8dMXliZd7mREVr6la4aXXXg5A==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -2758,10 +2687,10 @@
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
         "minimatch": "^10.2.5",
-        "semver": "^7.7.3",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.16",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -2837,6 +2766,16 @@
         "@otplib/plugin-thirty-two": "^12.0.1"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "dev": true,
@@ -2875,15 +2814,15 @@
       }
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2896,9 +2835,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2911,48 +2850,25 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.16.tgz",
+      "integrity": "sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2970,39 +2886,16 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
+      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3020,9 +2913,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3035,37 +2928,14 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz",
+      "integrity": "sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3083,12 +2953,12 @@
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3101,36 +2971,13 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
+      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3148,13 +2995,12 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3172,12 +3018,12 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
-      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.4"
+        "@radix-ui/react-slot": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3194,31 +3040,13 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3231,9 +3059,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3246,13 +3074,13 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3265,12 +3093,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3283,12 +3111,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3301,9 +3129,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3314,6 +3142,273 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@react-native/assets-registry": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.0.tgz",
+      "integrity": "sha512-nIaXbm2jX1OTYp0qbviJ3O6KZivoE8z3BnhUQ2LsqfZSWRoOK/n1qsiAr6oALiNKWnXY3j2KPwtYORnZzp8xew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/codegen": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.0.tgz",
+      "integrity": "sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.29.0",
+        "hermes-parser": "0.36.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "tinyglobby": "^0.2.15",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.0.tgz",
+      "integrity": "sha512-Jv8p1ebEPfTzs8gmrjsdT2XMXFfeAg45Pman+XPLFGaSeGAZkutRFRyX9Cs9aGTSOyIA9YPJ6vDNb1ayTf1FKQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@react-native/dev-middleware": "0.86.0",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "metro": "^0.84.3",
+        "metro-config": "^0.84.3",
+        "metro-core": "^0.84.3",
+        "semver": "^7.1.3"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@react-native-community/cli": "*",
+        "@react-native/metro-config": "0.86.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-community/cli": {
+          "optional": true
+        },
+        "@react-native/metro-config": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/debugger-frontend": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.0.tgz",
+      "integrity": "sha512-7Mb3nDfyJeys+ELF75Ageu7VKERlnIMoO+aNPoXqTXvz+b41L6l2CqMyLpDHxkBSlenij6gEepPNgaIyWHbJZw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/debugger-shell": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.0.tgz",
+      "integrity": "sha512-Y0zEkZzLz8ou6o/VLml1A31X/rMgc6DRjwxwzPMa94qRTMY070WeBCNTITQo4kKTBAUgbxh07oXPQqp0Tpja8w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.4.0",
+        "fb-dotslash": "0.5.8"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.0.tgz",
+      "integrity": "sha512-20pTO6yTybmvXvro520H6C7jydIQnLKOl5qFtVEcHSdFrY63r3OGei+Rx9bILgSRmH6jgnfEcijcMx7pwWuQtw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.86.0",
+        "@react-native/debugger-shell": "0.86.0",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.3.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^7.5.10"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/gradle-plugin": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.0.tgz",
+      "integrity": "sha512-a1RcfaEDqWExCGfCwadIxt4l8FvKYgFqeMf2uzeKyAOnb+vTGNIeCvifFL2MqvgaeYxlER437HbMIajGcuJ1pQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/js-polyfills": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.0.tgz",
+      "integrity": "sha512-zYy/Cjd1VTnZ2iCNaG9bDF9C3l2ntESiPRscjIlI5FKugu6aeTwsDSv1aI8Bc4Kp3vEdoVg+UQhLAhE4svREaQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/normalize-colors": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.0.tgz",
+      "integrity": "sha512-kG0wfCGghUKlfxkJyyHCDVutWVYWK7/DG58ojA/4v9EfulgF+osuSQmlbNb3rcKX58qutm7JcldSeVLgGFha9g==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@react-spring/animated": {
       "version": "9.7.5",
@@ -3387,24 +3482,10 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -3413,12 +3494,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -3427,12 +3511,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -3441,26 +3528,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -3469,12 +3545,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -3483,26 +3562,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -3511,12 +3579,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -3525,40 +3596,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -3567,54 +3613,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -3623,12 +3630,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -3637,12 +3647,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -3651,26 +3664,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -3679,12 +3681,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -3693,26 +3717,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -3721,21 +3734,24 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "peer": true
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.8",
@@ -4159,9 +4175,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4450,6 +4466,17 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "dev": true,
@@ -4543,6 +4570,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
@@ -4602,7 +4656,6 @@
     },
     "node_modules/@types/node": {
       "version": "20.19.19",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4708,6 +4761,23 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
@@ -4951,29 +5021,29 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4982,31 +5052,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -5015,7 +5085,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -5027,26 +5097,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -5054,13 +5124,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -5069,9 +5140,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5079,27 +5150,35 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wordpress/a11y": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.46.0.tgz",
-      "integrity": "sha512-9VKhQHB/TQHJciOtxbpJ5JPhxMHCOszcxs4eL27krFXMEp3fl4tzVy13r1LPuXg/yjZ9NpV3NY+Qwx4G0aW3Kw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.48.0.tgz",
+      "integrity": "sha512-MXwBc2sYaemZCn1dqVutTbLdM6iy4bx/HS9hHR/+pRpaSVJUlguZ1aQ0BaoIbE4u0uOezGGc5d2bDfWCti3Dww==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0"
+        "@wordpress/dom-ready": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5107,13 +5186,14 @@
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.46.0.tgz",
-      "integrity": "sha512-QOxuHSUXMzLat3Y90+0HNUDPSlBUK53r4mQ4m7f4/OKaWRRZU5jzvDBJyj52dEST7yJ1eZtuqUkEwK2T1MEBfQ==",
+      "version": "7.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.48.0.tgz",
+      "integrity": "sha512-WYoIikKQPdRqrbLB9b9diM80q4g80NqqMPwVYZY9c7vbhJvj5c0hkA5zAlwba/iRbwqDjpRiZMKp8XntYLzMWw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/url": "^4.46.0"
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/url": "^4.48.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5121,9 +5201,9 @@
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.46.0.tgz",
-      "integrity": "sha512-qAAd46EvbO5L9xx+YVP0lN48+A4n3C2jO4ckVP8/n8cEgFucCMlfyMKstqj7uOTBaA0YnmNZxJUkciCCV9FrLw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.48.0.tgz",
+      "integrity": "sha512-Fn0WzWJjwIFxSfF9RqB3L1XbKudWLGHc4DMTAN4KAfyVl+86FszP85UYJq28EWIMblPO4V1roNXt6ZbShmGsOw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -5131,9 +5211,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
-      "integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
+      "integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -5141,9 +5221,9 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.46.0.tgz",
-      "integrity": "sha512-TUu6k4SFPThT86ek/O87/aQfwKVYAGG9Gt14uvYPXPyLz90/KeFLr15v9waZV2luk2xCZACMIa4OdBHQlkL/aQ==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.48.0.tgz",
+      "integrity": "sha512-nMFyrFqdAMLeM2QzVN14UuWtBcbiftrcCmPZydZq05wcWs0pUIcd0Xe3D7o77GIfhlpRFOOC4iT7ORJE/YeWiA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -5151,49 +5231,49 @@
       }
     },
     "node_modules/@wordpress/block-editor": {
-      "version": "15.19.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.19.0.tgz",
-      "integrity": "sha512-kpTug+xiBLnbuN143nG9aNNEON4wrJGY3vM+s9XlKaNXIm+EeuOMv53Mm9HUKEJYctyPsPMFbfK7nVANWzC2fQ==",
+      "version": "15.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.21.0.tgz",
+      "integrity": "sha512-tSv8htNGX4LZfC91BCgcxpe2uU9wZAMGDFmpLYu6qSLg8ArhXJtbPt9YUigSPQJrM8XjD/29nW2PG779incBQA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/blob": "^4.46.0",
-        "@wordpress/block-serialization-default-parser": "^5.46.0",
-        "@wordpress/blocks": "^15.19.0",
-        "@wordpress/commands": "^1.46.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/dataviews": "^14.3.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/global-styles-engine": "^1.13.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/image-cropper": "^1.10.0",
-        "@wordpress/interactivity": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keyboard-shortcuts": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/notices": "^5.46.0",
-        "@wordpress/preferences": "^4.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-engine": "^2.46.0",
-        "@wordpress/token-list": "^3.46.0",
-        "@wordpress/ui": "^0.13.0",
-        "@wordpress/upload-media": "^0.31.0",
-        "@wordpress/url": "^4.46.0",
-        "@wordpress/warning": "^3.46.0",
-        "@wordpress/wordcount": "^4.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/blob": "^4.48.0",
+        "@wordpress/block-serialization-default-parser": "^5.48.0",
+        "@wordpress/blocks": "^15.21.0",
+        "@wordpress/commands": "^1.48.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/dataviews": "^16.0.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/global-styles-engine": "^1.15.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/image-cropper": "^1.12.0",
+        "@wordpress/interactivity": "^6.48.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keyboard-shortcuts": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/notices": "^5.48.0",
+        "@wordpress/preferences": "^4.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-engine": "^2.48.0",
+        "@wordpress/token-list": "^3.48.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/upload-media": "^0.33.0",
+        "@wordpress/url": "^4.48.0",
+        "@wordpress/warning": "^3.48.0",
+        "@wordpress/wordcount": "^4.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -5218,38 +5298,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/block-editor/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -5276,15 +5335,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -5294,25 +5354,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -5342,18 +5403,18 @@
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -5371,14 +5432,15 @@
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -5390,9 +5452,9 @@
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -5405,15 +5467,6 @@
       },
       "peerDependencies": {
         "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/gradient-parser": {
@@ -5437,50 +5490,50 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/block-library": {
-      "version": "9.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.46.0.tgz",
-      "integrity": "sha512-QI8CjmH7Ufa1MDjBxR2CVd0hLrY7hfTnPuzXjLNCWmW6FKUnNBCENMea4EuNvXuXUShbgX+VIao5NA8oLxtbIQ==",
+      "version": "9.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.48.0.tgz",
+      "integrity": "sha512-bcnC8yAFxqeLdN/gpS4M1zyJIA9yTO7hrDw3KFVGBysFzFWJ3mOtNXgGBIKEyPBKaK413PmITT4rro3A+1bXtQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@arraypress/waveform-player": "1.2.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/api-fetch": "^7.46.0",
-        "@wordpress/autop": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/blob": "^4.46.0",
-        "@wordpress/block-editor": "^15.19.0",
-        "@wordpress/blocks": "^15.19.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/core-data": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/interactivity": "^6.46.0",
-        "@wordpress/interactivity-router": "^2.46.0",
-        "@wordpress/keyboard-shortcuts": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/latex-to-mathml": "^1.14.0",
-        "@wordpress/notices": "^5.46.0",
-        "@wordpress/patterns": "^2.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/reusable-blocks": "^5.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/server-side-render": "^6.22.0",
-        "@wordpress/shortcode": "^4.46.0",
-        "@wordpress/ui": "^0.13.0",
-        "@wordpress/upload-media": "^0.31.0",
-        "@wordpress/url": "^4.46.0",
-        "@wordpress/viewport": "^6.46.0",
-        "@wordpress/wordcount": "^4.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/api-fetch": "^7.48.0",
+        "@wordpress/autop": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/blob": "^4.48.0",
+        "@wordpress/block-editor": "^15.21.0",
+        "@wordpress/blocks": "^15.21.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/core-data": "^7.48.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/interactivity": "^6.48.0",
+        "@wordpress/interactivity-router": "^2.48.0",
+        "@wordpress/keyboard-shortcuts": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/latex-to-mathml": "^1.16.0",
+        "@wordpress/notices": "^5.48.0",
+        "@wordpress/patterns": "^2.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/reusable-blocks": "^5.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/server-side-render": "^6.24.0",
+        "@wordpress/shortcode": "^4.48.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/upload-media": "^0.33.0",
+        "@wordpress/url": "^4.48.0",
+        "@wordpress/viewport": "^6.48.0",
+        "@wordpress/wordcount": "^4.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -5500,38 +5553,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-library/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/block-library/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-library/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -5558,15 +5590,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -5576,25 +5609,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -5624,18 +5658,18 @@
       }
     },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -5653,14 +5687,15 @@
       }
     },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -5672,9 +5707,9 @@
       }
     },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -5710,9 +5745,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.46.0.tgz",
-      "integrity": "sha512-j9AWXtuBbjntWWapDTZVyLmRVYOA1me3lqR+ugkN54HvNiyQaDw0tt6JfJYGFTWhJ8peU90G2TO+IiFf6YDKQQ==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.48.0.tgz",
+      "integrity": "sha512-bbG7qlz3BZNnZRLtwwFl/VK/ynDtZ3XDbLiTCXrOGF3ij4RdA+Vng3nTNBxxPKLy8gB5t8Fgl5DGK3MXhn+RWA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -5720,26 +5755,26 @@
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "15.19.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.19.0.tgz",
-      "integrity": "sha512-8tsKYt9uD8xU+G0o2MwHVYgPz60FhyE1eSNHx27YS20VxgZPzIWPTRnAB45wEyjQ2yMcN/9G8maim+B7geQ0Kg==",
+      "version": "15.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.21.0.tgz",
+      "integrity": "sha512-nq+lOxGFAET150U2dbC/yf5M1l52NlGFffKDr3ChmKscGh4R5KRYfv4fmqQVYujbapWCNJHZJXI63yrSFUOhMA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/autop": "^4.46.0",
-        "@wordpress/blob": "^4.46.0",
-        "@wordpress/block-serialization-default-parser": "^5.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/shortcode": "^4.46.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/autop": "^4.48.0",
+        "@wordpress/blob": "^4.48.0",
+        "@wordpress/block-serialization-default-parser": "^5.48.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/shortcode": "^4.48.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
         "fast-deep-equal": "^3.1.3",
@@ -5761,18 +5796,18 @@
       }
     },
     "node_modules/@wordpress/blocks/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -5790,14 +5825,15 @@
       }
     },
     "node_modules/@wordpress/blocks/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -5809,9 +5845,9 @@
       }
     },
     "node_modules/@wordpress/blocks/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -5833,21 +5869,21 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.46.0.tgz",
-      "integrity": "sha512-Pzn9noMCkmFs+tRd5ghpkJy1iZtc0EfHU8XQTKoL2rtafs5Sxhsw08+85RNci/Uk7FZKhDTjKCgy7bxlyZ4EIQ==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.48.0.tgz",
+      "integrity": "sha512-wSo0Sj0Y7Z+yNfhp8QouB7rBSC9d3+Vb2/RKB/480+WlidFvCDgsFJPojNenqXdPlUTVcbgjsj0jLls8BbwHbA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/keyboard-shortcuts": "^5.46.0",
-        "@wordpress/preferences": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/keyboard-shortcuts": "^5.48.0",
+        "@wordpress/preferences": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/warning": "^3.48.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
@@ -5860,38 +5896,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/commands/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/commands/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -5918,15 +5933,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -5936,25 +5952,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -5984,18 +6001,18 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -6013,14 +6030,15 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -6032,9 +6050,9 @@
       }
     },
     "node_modules/@wordpress/commands/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -6437,19 +6455,20 @@
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
-      "integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+      "integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/undo-manager": "^1.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/undo-manager": "^1.48.0",
         "change-case": "^4.1.2",
         "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
@@ -6463,14 +6482,15 @@
       }
     },
     "node_modules/@wordpress/compose/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -6482,27 +6502,27 @@
       }
     },
     "node_modules/@wordpress/core-data": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.46.0.tgz",
-      "integrity": "sha512-mfiqOrXcsv4rZJZFYjmUSc5goK1cKpuQ1lSoSBnuKMJNZAxTCVTwexIaj0XI5Qr/ngUjT5U1+w4I0Fzuv/qCMQ==",
+      "version": "7.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.48.0.tgz",
+      "integrity": "sha512-coukurBp/mTSugI1PRKwunJsk9/sVilwdFv5h4yFWisVIMclZQ0GJg+MOLiK18fWEtqjPD2J1j7Aoz12QEx1Lw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.46.0",
-        "@wordpress/block-editor": "^15.19.0",
-        "@wordpress/blocks": "^15.19.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/sync": "^1.46.0",
-        "@wordpress/undo-manager": "^1.46.0",
-        "@wordpress/url": "^4.46.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/api-fetch": "^7.48.0",
+        "@wordpress/block-editor": "^15.21.0",
+        "@wordpress/blocks": "^15.21.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/sync": "^1.48.0",
+        "@wordpress/undo-manager": "^1.48.0",
+        "@wordpress/url": "^4.48.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -6519,18 +6539,18 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -6548,14 +6568,15 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -6567,9 +6588,9 @@
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -6768,26 +6789,26 @@
       }
     },
     "node_modules/@wordpress/dataviews": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
-      "integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-16.0.0.tgz",
+      "integrity": "sha512-02rbslxalTNasLV8w/zAifCsUU5Pug8GiduWIEKRiNtazvJ8duz8fIcQ2Jgl31ruRItcu3fcG7XUk1OtwsdcZQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.21",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/ui": "^0.13.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
         "date-fns": "^4.1.0",
@@ -6804,38 +6825,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/dataviews/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/dataviews/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -6862,15 +6862,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -6880,25 +6881,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -6928,18 +6930,18 @@
       }
     },
     "node_modules/@wordpress/dataviews/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -6957,14 +6959,15 @@
       }
     },
     "node_modules/@wordpress/dataviews/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -6976,9 +6979,9 @@
       }
     },
     "node_modules/@wordpress/dataviews/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -7014,12 +7017,12 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/date": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.46.0.tgz",
-      "integrity": "sha512-phbKy1siTFGwFet5hQzaSZJB1mMDIXflMLKj+oJ/mT/m9ughp3seFDPvKoL+UzukLxNJh3l5G5h1l9XQFfC2cA==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.48.0.tgz",
+      "integrity": "sha512-HgXtYAD2IOrPDY83xzkT/8abYj2nMlkbC+lfSpB4lExlSVrIbz5oYUtktH8k5EBZjVBMFsE7mdMQyQjUeCQbeQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.46.0",
+        "@wordpress/deprecated": "^4.48.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -7029,12 +7032,12 @@
       }
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.46.0.tgz",
-      "integrity": "sha512-d4Dy9GeJ/VIORTgYKYXT026/hhpV6VOf3VUDj10f+QFoIJ86VMBrzV6KQn8KUVH4T3oH1MSpo/A5t8ttYFemsg==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.48.0.tgz",
+      "integrity": "sha512-aTa7oww6hvTjfIvxLsxlcwYj7skAGPnr1V2S0iBVQfiIn5wJPiGjM9hz4QEf6kyR44Vh0IYjW9wSxVuDMGZUdw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.46.0"
+        "@wordpress/hooks": "^4.48.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7042,12 +7045,12 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.46.0.tgz",
-      "integrity": "sha512-XngkvNJpf0JnpZuOcsbBl/cTprfYQTfSykttIL4laXcFXfZe8rU3bGgv8K7AEoYigDwxfw3g/yMPi4fn195Kpw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.48.0.tgz",
+      "integrity": "sha512-9UARZ0YQfmhx9VAi+QynSwu5fOJoG4mmPNTpYW8jDmtKh+9c2YIi1YSQFuOa1sipj78ZLPaBxaceZ7dbxKc3UA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.46.0"
+        "@wordpress/deprecated": "^4.48.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7055,9 +7058,9 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.46.0.tgz",
-      "integrity": "sha512-CQ6KPaCkMzAmbxmR4E4Fu99ngyPpkP9VGaIFu0xUgx0ubkYOzcvEfEEPuyEV3n7PY2Jg/XWzBilgWCa8PmaxWw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.48.0.tgz",
+      "integrity": "sha512-jtH9/4FBTsfYLJDzgiXs41nceTrfvuLXqaWa5IN8drHvXZde6Dhz78m3KCZLrOB5DEE1tbyBNyZkcWM8HNVZ0Q==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7096,9 +7099,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.46.0.tgz",
-      "integrity": "sha512-SzrVQwLQBZdaSStYVpTKeYqp97NABz1w551T8me3msDDsfhWWPhSZiZTNaGZ6iqUNfOX2uKyZsqXedvkqwLHqA==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.48.0.tgz",
+      "integrity": "sha512-phw399RofSqTqIM4DikmkDfgJ7exDYgPfDuxjv3D2YnUTTUsR+U9fA+pA+/rNUiZD1YOmVILQmkJt6oLaVM+nQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7106,15 +7109,15 @@
       }
     },
     "node_modules/@wordpress/global-styles-engine": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.13.0.tgz",
-      "integrity": "sha512-rOix+U4tAi3X9m0q82r7gQrDQ0uJzK/w5Pc9s7yawbWo5T7oW8FLor17VkTr5T75ZItV9OZshpAA0xELIdJZRw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.15.0.tgz",
+      "integrity": "sha512-okgCtWjuy4AH6+yu7Rn9p4t1l9Cc8dtaJbV4dDr3mIg9w77amw4gjOlqpx6TU3iM/2RW8GNzinhNMoK1zYZe6g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blocks": "^15.19.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/style-engine": "^2.46.0",
+        "@wordpress/blocks": "^15.21.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/style-engine": "^2.48.0",
         "colord": "^2.9.2",
         "deepmerge": "^4.3.0",
         "fast-deep-equal": "^3.1.3",
@@ -7127,18 +7130,18 @@
       }
     },
     "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -7156,14 +7159,15 @@
       }
     },
     "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -7175,9 +7179,9 @@
       }
     },
     "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -7199,9 +7203,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.46.0.tgz",
-      "integrity": "sha512-fsKw4dmw4voIRoKc8t0XRREQlFvwj9XS/jTXvkh6mqRYCDpaEnrdB2Ji5jgbRXEMPU0GKVGMeAn5Wwi56gjBMg==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.0.tgz",
+      "integrity": "sha512-rU1yGEy0Mb+2oRG5QX/bKIIwKQmYAvATfUQeXIF20/mbR0qutYeVTCIvWEyb4pf71tvnQFiN18RWRXWsvKrDbQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7209,9 +7213,9 @@
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.46.0.tgz",
-      "integrity": "sha512-YJ/V9R2p4lwYkhc9/bQrXxoX0rNDtt1WQGInKAxRWqF1w1gYQk0iWiwGcNnahnFofwK2LJSVf4/jYFjJrS/sPw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.48.0.tgz",
+      "integrity": "sha512-KGxdaLC36wE10GybSfjYGcyWiy+KQCYheB6T8jhZhQ9mlf2Zwx6aJgfZm/L6BLwNN33Efx+sJY3nvMIxI5UwnA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7219,13 +7223,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.19.0.tgz",
-      "integrity": "sha512-hRXd2E0SF9OQf22ZZWw7Ny/o+Q9u8jINiF1p0bF+rnSDKQUgoStihak6YiazWVRiIEYwctzotKXlt0HePJelXA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
+      "integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.46.0",
+        "@wordpress/hooks": "^4.48.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -7239,13 +7243,13 @@
       }
     },
     "node_modules/@wordpress/icons": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.1.0.tgz",
-      "integrity": "sha512-KMZAeYghsLs6e5wKMZ3/Ynrsuu5yZt2gAlMHmZSkWJKQFld++Pz/pEj8nDCJ79z/zx9FO7q4teG49vHHvVosjQ==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+      "integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/primitives": "^4.46.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/primitives": "^4.48.0",
         "change-case": "4.1.2"
       },
       "engines": {
@@ -7257,14 +7261,15 @@
       }
     },
     "node_modules/@wordpress/icons/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -7276,14 +7281,14 @@
       }
     },
     "node_modules/@wordpress/image-cropper": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.10.0.tgz",
-      "integrity": "sha512-Aq4Wz2nGf+GYZPi+n+nWq7AtsGSjUbREzYKEUQIAnt2pPGn2ZkvooBUQE405WOqoJadE+tkLjKdyjY24iOtocA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.12.0.tgz",
+      "integrity": "sha512-mOoMaVMC+HtxvPM2Iq+I3qXHoHhcsEEc1hiLUjfS8KIGUkm11LSk/LeHjhpnA1My8gAeUqYREFCwPoK91+rEFA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/i18n": "^6.19.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/i18n": "^6.21.0",
         "clsx": "^2.1.1",
         "dequal": "^2.0.3",
         "react-easy-crop": "^5.4.2"
@@ -7297,38 +7302,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/image-cropper/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/image-cropper/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/image-cropper/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -7355,15 +7339,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/image-cropper/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -7373,25 +7358,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -7421,14 +7407,15 @@
       }
     },
     "node_modules/@wordpress/image-cropper/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -7454,9 +7441,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.46.0.tgz",
-      "integrity": "sha512-z/MbS0WzW7yQIMg45lG5Vfl1JQ3rWioNhLSNotCWuBZ191AGsJiZWHzyJE57MV6n+Nm5NMNN4Pe7S4qA3/9oWQ==",
+      "version": "6.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.48.0.tgz",
+      "integrity": "sha512-61VSanGsCASE1yBtMHC7s1HSZw24sF+HZNWiPsP95ZP9EKWlhTHAyKyhv99+PJUnSL/oSNYQNQeQDwABMPc7oA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@preact/signals": "^1.3.0",
@@ -7468,13 +7455,13 @@
       }
     },
     "node_modules/@wordpress/interactivity-router": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.46.0.tgz",
-      "integrity": "sha512-d/171ViZFCXzX0OhobQ/K6tZRyLdJSLH+6WOIQqn8PLT8QFn/Y0pB+JDsHkjqsgVft0+WPqPZQSqjz/eee3g5w==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.48.0.tgz",
+      "integrity": "sha512-II5THt2l+MP0aP3bSZou0//7OYmffy8kKucD3hfhRILi0FKHLXc378HM+uwd9FOoPPDmnB2+0y4D4JMcz214EQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/interactivity": "^6.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/interactivity": "^6.48.0",
         "es-module-lexer": "^1.5.4"
       },
       "engines": {
@@ -7483,9 +7470,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.46.0.tgz",
-      "integrity": "sha512-46J36GNPw7q3c5HF0RurUx9yJHvBDYqOFVqbb8Td8bov9pVI6TGtcMKd+/O+Q89ZUVSTVx/NfxKjNwXpeQQCmg==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.48.0.tgz",
+      "integrity": "sha512-7ipiZ1+m84RfuVhiMbtKm6RN571W3ERV/pTL+fSG2qOVhLqccFmliuFHTKQG+0KIhV8DegOlE6eoKOenf+I9ng==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7493,14 +7480,14 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.46.0.tgz",
-      "integrity": "sha512-zEnaatKpFaSUFrvxjY9G4xLWg7AjXv3vgVcY6k8R5eCLJTdhfRI+hmG8Zf5eyS4BnFPzUyv3orQ3iK8GgnvTdw==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.48.0.tgz",
+      "integrity": "sha512-j4EXbAykqrmauDRKSHvr1FimH4thsHUXVfGjNPzDqF0JQGqCgribqslKANNYJXrDQplt2aHhO0XHYZXxpNfgbQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/keycodes": "^4.46.0"
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/keycodes": "^4.48.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7511,18 +7498,18 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -7540,14 +7527,15 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -7559,9 +7547,9 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -7583,12 +7571,12 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.46.0.tgz",
-      "integrity": "sha512-+eW0b4bRrpmiOOfdmz1BtQsbTqWqCkgJyeiR5yMLJ+sGG2He9icVLjt/fSc4xCQ56MhT03Zypb33L6j+zJFEgA==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.48.0.tgz",
+      "integrity": "sha512-u3Uxxe3rDAqEmerAiJ2X94s7iO3ZVgS+10MFyD4nWhfuB/C6m/M2TqHPgZiKvyDH04EIhe+pIF2KFO4pq7NWsw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.19.0"
+        "@wordpress/i18n": "^6.21.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7596,9 +7584,9 @@
       }
     },
     "node_modules/@wordpress/latex-to-mathml": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.14.0.tgz",
-      "integrity": "sha512-kLzovQBKlBSHsqXICIclUBOFCm9ROEmXU+xUaV6UpS2pb4BIcsBew/z8URKMHtYA/jRhDM9uejEy45YMI8swZw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.16.0.tgz",
+      "integrity": "sha512-WEXC9GKgMLXXqbezKZWw9cwozS4/dM23VDresod1nqfvgMSpvtgHsFP98wJWg2iQyA6SIksSuD/SROSaBCZ17A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "temml": "^0.10.33"
@@ -7609,14 +7597,14 @@
       }
     },
     "node_modules/@wordpress/notices": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.46.0.tgz",
-      "integrity": "sha512-HwU051rXauCsnCtW4naXUJkWvanNOmkzI6B5bUl+S4IHAUAVrr0oITgZcXEk6mJJuKFs7pMDiWAB5XhYixcsyw==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.48.0.tgz",
+      "integrity": "sha512-s1vRbDlJDcFFQnlUaYIZDiVlMpBnlmZk4y2EjRawoCZApiz1V+Yx/mHDqIrFrM7l50ZI3Dh63wDdu2qzNgc7wQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/data": "^10.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/data": "^10.48.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -7627,38 +7615,17 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/notices/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/notices/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -7685,15 +7652,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/notices/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -7703,25 +7671,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -7751,18 +7720,18 @@
       }
     },
     "node_modules/@wordpress/notices/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -7780,14 +7749,15 @@
       }
     },
     "node_modules/@wordpress/notices/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -7799,9 +7769,9 @@
       }
     },
     "node_modules/@wordpress/notices/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -7837,26 +7807,26 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/patterns": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.46.0.tgz",
-      "integrity": "sha512-o9B+uvkoWIVtuevqrESNft43ap3ElKGFcjA3Obabn2hqA8EYb6dgF8HBc+Na933voEK6toT2seqwuLGDKLOaOA==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.48.0.tgz",
+      "integrity": "sha512-6RCHrdfS8cMw+JIyhISYqNux7tvavDhzZMP+2RTNKrqVqEXHxO0MCtk/NX5L9GfJ3kr46QVBrrZUqB2X/o+wJg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/block-editor": "^15.19.0",
-        "@wordpress/blocks": "^15.19.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/core-data": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/notices": "^5.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/url": "^4.46.0"
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/block-editor": "^15.21.0",
+        "@wordpress/blocks": "^15.21.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/core-data": "^7.48.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/notices": "^5.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/url": "^4.48.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7867,38 +7837,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/patterns/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/patterns/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -7925,15 +7874,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/patterns/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -7943,25 +7893,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -7991,18 +7942,18 @@
       }
     },
     "node_modules/@wordpress/patterns/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -8020,14 +7971,15 @@
       }
     },
     "node_modules/@wordpress/patterns/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8039,9 +7991,9 @@
       }
     },
     "node_modules/@wordpress/patterns/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -8077,21 +8029,21 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/preferences": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.46.0.tgz",
-      "integrity": "sha512-vLvkOKmziv/D0ksC8wZ94bAeIAvXQm+X86Bte36kXXEvrru2+QGxCz4pHT+qOdkkALzS2cKXc7prqRCigRzJwg==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.48.0.tgz",
+      "integrity": "sha512-ae8SOpc+NTFf5dB1bgN4RwMCzCQC/gX0d72SDxqtBeU1N52+sihunob9bhPLAEimKS/nMR/kU+YS9j9y5jyZ0A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/private-apis": "^1.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/private-apis": "^1.48.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8103,38 +8055,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/preferences/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/preferences/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -8161,15 +8092,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -8179,25 +8111,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -8227,18 +8160,18 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -8256,14 +8189,15 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8275,9 +8209,9 @@
       }
     },
     "node_modules/@wordpress/preferences/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -8313,12 +8247,12 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.46.0.tgz",
-      "integrity": "sha512-x1IhEVa/aGDe6otGJ4VIqEioQGfIeK5B1VQm32+ycqinJRbtbw9F5bgx4ARIdnm5M1Lg63oV9Bhmg/XMyGSTZA==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.48.0.tgz",
+      "integrity": "sha512-dfF7IZotIqb6LUiGs7oPwKbSF8RPoC0JDSIrtxvgwFA/yvbc/pDIp/Zs0O8GvxZNxu4JIVnKskOhoLq7lAeziQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.46.0",
+        "@wordpress/element": "^8.0.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -8330,14 +8264,15 @@
       }
     },
     "node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8349,9 +8284,9 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.46.0.tgz",
-      "integrity": "sha512-rjwzO/I7Os16VMJFVdzIeXMmyvwe+DbODrXl3mgW5LZZeIYob94d++pjQxUdWN1/0APnXPQP6zk4yFfSLOVkYg==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.48.0.tgz",
+      "integrity": "sha512-NuGrfSSnBC794erb3xSEKrzWLGCNLa+ukob0pyVRtnebU7fPgrhx4NCBCXYK1vTcAta3NAkOVRfUZgcmLFYA6g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -8362,9 +8297,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.46.0.tgz",
-      "integrity": "sha512-l8dsEuxq6CrtsI7Twfpn6CbPHmGBUQoGN4oLPJG1Bqsr1yXXLU/bEx9KAQN9emxRjXaELPsn7x7TVx0TUoKyJw==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.48.0.tgz",
+      "integrity": "sha512-HHOSXLCAlBggfMozwWtX36wgsSt22g2tZwpka47Rjzr3hNY1BZ6SrrFJumiNxooy5PDKbRgcF092PAF82hdJXg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8390,23 +8325,23 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.46.0.tgz",
-      "integrity": "sha512-bAX9YGgb8OfTxNKimxzfuWj/39EP9jtJXKVYcChDgYPKH1gl02I8+OdyFx+RycWFxRjMTwsgL5WEjgkGC6nokA==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.48.0.tgz",
+      "integrity": "sha512-7WdKxKGP7PWSUuatuUoLrum+gapJ/Dqq2zp0zMGtjR+mH5/TQ483TR/TyDT09H49uWYgLSST+pT++KVo5PUNxg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/block-editor": "^15.19.0",
-        "@wordpress/blocks": "^15.19.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/core-data": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/notices": "^5.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/url": "^4.46.0"
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/block-editor": "^15.21.0",
+        "@wordpress/blocks": "^15.21.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/core-data": "^7.48.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/notices": "^5.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/url": "^4.48.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8417,38 +8352,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/reusable-blocks/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -8475,15 +8389,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -8493,25 +8408,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -8541,18 +8457,18 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -8570,14 +8486,15 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8589,9 +8506,9 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -8627,21 +8544,21 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.46.0.tgz",
-      "integrity": "sha512-XxuCe0gWq5YYfN+EdL5RmL4/qMlVka0R+n51/DzEpWM/+CkPInpXBeYE+3z9Ip+sRcnEgE1zKkMo1wjXWTDOjw==",
+      "version": "7.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.48.0.tgz",
+      "integrity": "sha512-rMiTTpRnpdynL9BnuI2MkSXzd12Js8gYSnlbVwxNNKNeFEXT+3Ah2oNCGvSb82pD/73Bl5BIGC5395D5a3X9yw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -8654,18 +8571,18 @@
       }
     },
     "node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -8683,14 +8600,15 @@
       }
     },
     "node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8702,9 +8620,9 @@
       }
     },
     "node_modules/@wordpress/rich-text/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -8726,20 +8644,20 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/server-side-render": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.22.0.tgz",
-      "integrity": "sha512-WnQr9PsAKDoirFo2ZA7O/rhhvB/XpHJDZbAbOgUqHRna2PvtHIPy3k46Xgbn4RNXxCxsOGy5mcZXd2OP4mD1mg==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.24.0.tgz",
+      "integrity": "sha512-cmn8cWW+N4Qpf/wnSjPSWW/QJ/82K1pvxDh5tihd5ovYiKZFTD0P/Z37UMTE+NdC7AzYQGiWzDgUq3Zo33DadQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.46.0",
-        "@wordpress/blocks": "^15.19.0",
-        "@wordpress/components": "^33.1.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/url": "^4.46.0"
+        "@wordpress/api-fetch": "^7.48.0",
+        "@wordpress/blocks": "^15.21.0",
+        "@wordpress/components": "^35.0.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/url": "^4.48.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8750,38 +8668,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/server-side-render/node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "license": "MIT"
-    },
     "node_modules/@wordpress/server-side-render/node_modules/@ariakit/react": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.26"
+        "@ariakit/react-components": "0.1.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -8808,15 +8705,16 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
-      "version": "33.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-      "integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
+      "integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.22",
         "@date-fns/utc": "^2.1.1",
         "@emotion/cache": "^11.14.0",
         "@emotion/css": "^11.13.5",
+        "@emotion/native": "^11.11.0",
         "@emotion/react": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/styled": "^11.14.1",
@@ -8826,25 +8724,26 @@
         "@types/highlight-words-core": "1.2.1",
         "@types/react": "^18.3.27",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/base-styles": "^8.0.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/date": "^5.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/escape-html": "^3.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/html-entities": "^4.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/rich-text": "^7.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/warning": "^3.46.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/base-styles": "^9.1.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/date": "^5.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/html-entities": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/rich-text": "^7.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/ui": "^0.15.0",
+        "@wordpress/warning": "^3.48.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -8874,18 +8773,18 @@
       }
     },
     "node_modules/@wordpress/server-side-render/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -8903,14 +8802,15 @@
       }
     },
     "node_modules/@wordpress/server-side-render/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8922,9 +8822,9 @@
       }
     },
     "node_modules/@wordpress/server-side-render/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -8960,9 +8860,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.46.0.tgz",
-      "integrity": "sha512-s+1p9Zondd53T3u8ovs9ef3cy8uShnpMCSeAF9OFr7SLr/GIzScDRaXJPGCofU3tGwTe6Om81j69DAjHEcSYIw==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.48.0.tgz",
+      "integrity": "sha512-frF+OdYHJBptTdJzFGOBs7tTpvIFf01Q0vNHdzzZAFMaeA1SzwotRj8mntNlSg2aeX5HNkhzxdDzGNA5wdqQxA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "memize": "^2.0.1"
@@ -8973,9 +8873,9 @@
       }
     },
     "node_modules/@wordpress/style-engine": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.46.0.tgz",
-      "integrity": "sha512-3kUcomd7xbqV4KoDA0OIVbKb4HnCnvx4kWrohHfS8+r0gsW4LyMQr66WwV2u44U6eckn83Nw0sK1Jb+4PwWiNw==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.48.0.tgz",
+      "integrity": "sha512-KC2WaAH1ElIbHx/6A3PkagR7yBZS9ftlIorKphFWwZtpHZu1niZoSzsSuk/gaTsV0AZBwiZA2RNtf0C6SDmCww==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "change-case": "^4.1.2"
@@ -8986,9 +8886,9 @@
       }
     },
     "node_modules/@wordpress/style-runtime": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
-      "integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.4.0.tgz",
+      "integrity": "sha512-frzAg1rsn8X0KNgrxxLxszLvWCKY0Nk2e8j8Mjm2pI2URmS8Et7NefuXP3JnHBD4U1L1Ug9yKO/FA65ojQ7CEA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -8996,15 +8896,15 @@
       }
     },
     "node_modules/@wordpress/sync": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.46.0.tgz",
-      "integrity": "sha512-g7lTru47e4VonYFwvQRwX8Cj+o3n7p0SW1YXgwoIRP9cc7ce5Ipb2X+zqrnT81SN/wFqzH3mZDVNRvksqKQakw==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.48.0.tgz",
+      "integrity": "sha512-nkDL58Xzl4UoDAhlHJu3pkpHljQiw88hKNJZBUr6DsBIIRhWR4wLE0aiCW7oeGwZLYaFC0Stxv1QpDQ2oSS48A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.46.0",
-        "@wordpress/hooks": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/undo-manager": "^1.46.0",
+        "@wordpress/api-fetch": "^7.48.0",
+        "@wordpress/hooks": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/undo-manager": "^1.48.0",
         "diff": "^8.0.3",
         "fast-deep-equal": "^3.1.3",
         "lib0": "0.2.99",
@@ -9016,15 +8916,24 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/sync/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/@wordpress/theme": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.13.0.tgz",
-      "integrity": "sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.15.0.tgz",
+      "integrity": "sha512-qoozJ4YEPb0LvTBnTMj8a7kPlQtT2LeGL7b/vKJkvnB9dIEUOED5c0rpeRZJoK9b77fpUH5GwYzPE3IWiQ6l2w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
         "colorjs.io": "^0.6.0",
         "memize": "^2.1.0"
       },
@@ -9044,14 +8953,15 @@
       }
     },
     "node_modules/@wordpress/theme/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -9063,9 +8973,9 @@
       }
     },
     "node_modules/@wordpress/token-list": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.46.0.tgz",
-      "integrity": "sha512-g9UytUCFcLnj8LWNHFUK0c53FeokTEXDlZ3C3VrpDnxq0jC0BnNj0uJCAmbzfehg23LWI2O5xnQzmpAJ9ldAKg==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.48.0.tgz",
+      "integrity": "sha512-KrtNnVI9YAqBspjzKR3ELBexOQvIzxqfEuq6CasXr9w7vHn7YkEGSwbeZGNz5dEVirPFDnwAK2uVpuT8dvFiWA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9073,22 +8983,22 @@
       }
     },
     "node_modules/@wordpress/ui": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
-      "integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.0.tgz",
+      "integrity": "sha512-7aAx1ovnC6JOb4Qfcnfk8ESfB0RTm6rqsdFrUn7TEY3LON/aEQisCb/bd7Yb8s9txb1GfaJYkgjiTvrr0M6EWA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@wordpress/a11y": "^4.46.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/icons": "^13.1.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/primitives": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/style-runtime": "^0.2.0",
-        "@wordpress/theme": "^0.13.0",
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/icons": "^13.3.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/primitives": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/style-runtime": "^0.4.0",
+        "@wordpress/theme": "^0.15.0",
         "clsx": "^2.1.1",
         "tabbable": "^6.4.0"
       },
@@ -9102,14 +9012,15 @@
       }
     },
     "node_modules/@wordpress/ui/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -9121,12 +9032,12 @@
       }
     },
     "node_modules/@wordpress/undo-manager": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.46.0.tgz",
-      "integrity": "sha512-vAchoUrF97IdjqVD30Iz7NI9YvDtgeMNPshgjsrM8MF9nOCMq2tBWb3HS+ue/kQknfAuU73FEnn/UNKt0JPH4Q==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.48.0.tgz",
+      "integrity": "sha512-HqPGxMvZeWZJ6AVaCqZhfGpH6tqq5+hMlaqh4aCO0SvZ2Gvc6fbXEoVpqWfKozO1DyJW2GnRf8At8PpPt2IopQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.46.0"
+        "@wordpress/is-shallow-equal": "^5.48.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9134,20 +9045,20 @@
       }
     },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.31.0.tgz",
-      "integrity": "sha512-fpg1wx1p04AEyemQ7EGsR1c2oHcHCgsVdKbSl27L4Nvw2YlhiZY6yb/BOqUNyBqTJ6OBS85vKace6JzW6KR27w==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.33.0.tgz",
+      "integrity": "sha512-jtAbDbk6yuW74HqavA90lr59eSENTdwAKjkCgjZlLLt4zHSFXAxYuDWLk+ouaW0xnjqfWKl2/ByQGyjKes/YRA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blob": "^4.46.0",
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/i18n": "^6.19.0",
-        "@wordpress/preferences": "^4.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/url": "^4.46.0",
-        "@wordpress/vips": "^1.6.0",
+        "@wordpress/blob": "^4.48.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/preferences": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/url": "^4.48.0",
+        "@wordpress/vips": "^2.1.0",
         "uuid": "^14.0.0"
       },
       "engines": {
@@ -9160,18 +9071,18 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -9189,14 +9100,15 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -9208,9 +9120,9 @@
       }
     },
     "node_modules/@wordpress/upload-media/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -9232,9 +9144,9 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/url": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.46.0.tgz",
-      "integrity": "sha512-LGja+dYBzaNkkPSE5ddPgk03M66wadUheuhyOLTu4uLQU2UmipN9qQgI4VAnZLrnXs7dqb4fJ8f0AuNmshHpbg==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.48.0.tgz",
+      "integrity": "sha512-NfhCvFyJnKQ7XnqLlFXbigwZzhnNQZPgS+mpXTkttq/d0/b62TgvjQd5XIu5wiEkWXye7rmZfdkRmG8fWmEb3Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "remove-accents": "^0.5.0"
@@ -9245,14 +9157,14 @@
       }
     },
     "node_modules/@wordpress/viewport": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.46.0.tgz",
-      "integrity": "sha512-n/kfg5x/lGCK3FkyxrMh+D3LOk5FDPpbCtq81wtvy8Xy+GwuU4g2quRhfYENoia13tp6HVX52fyugRIGZmM/sg==",
+      "version": "6.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.48.0.tgz",
+      "integrity": "sha512-mP9BAg4xsFMiActGBjmADqcws+URFloJEfOFiCDe8y1BqWHdeNaUBC1cjXcgYj4hjmcij/lCBVdccKHg6BEAgg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/data": "^10.46.0",
-        "@wordpress/element": "^6.46.0"
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/element": "^8.0.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9263,18 +9175,18 @@
       }
     },
     "node_modules/@wordpress/viewport/node_modules/@wordpress/data": {
-      "version": "10.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.46.0.tgz",
-      "integrity": "sha512-vxOO2IEn+29eue9Pq7Mzsq1SipMAg0Rp0Oztz9LsgWQIF9yyylGlP3yHnFjEmJ4MonGSjzvpArlc7jWwkzutKg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.46.0",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/private-apis": "^1.46.0",
-        "@wordpress/redux-routine": "^5.46.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -9292,14 +9204,15 @@
       }
     },
     "node_modules/@wordpress/viewport/node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -9311,9 +9224,9 @@
       }
     },
     "node_modules/@wordpress/viewport/node_modules/@wordpress/redux-routine": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.46.0.tgz",
-      "integrity": "sha512-a4dzJrvqOB/DYXo9eoO6q0f9pTlo+P1/0s1Bzf0EU5RF4PTNjL9d2lYesM7xDhg0MYFLnVzklcriAeapIEv/ag==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -9335,12 +9248,12 @@
       "license": "MIT"
     },
     "node_modules/@wordpress/vips": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-1.6.0.tgz",
-      "integrity": "sha512-TiQYzS5L2hVk6H9Xpk0tSzMu0cpCLUXNCXioiM/LZ2SvzP9ibwp+uXp2QwI2SS32aO06OeECaCJx+qgbIimv3A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.1.0.tgz",
+      "integrity": "sha512-XaLh9CLDv6xcimDuXr4roUgAFsZ34jaW9I0zichRonjSmxtZCiSbHUaPtmz0pkBuoJe4Uiv/GTIBMnMBxb2Z5g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/worker-threads": "^1.6.0",
+        "@wordpress/worker-threads": "^1.8.0",
         "wasm-vips": "^0.0.16"
       },
       "engines": {
@@ -9349,9 +9262,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.46.0.tgz",
-      "integrity": "sha512-Z1CE6x732iMD+NcWziitqWUyhxVy1JlioHDtQUU2oqhDcA0d/P2ifOc/af02dDYFIuLh7umurU19LqpBX6EoWw==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.48.0.tgz",
+      "integrity": "sha512-En+A99j8aySNzUH0iXok0H2Xi+Uw2useKqYsvPm33VEMa0a0XIwa2I9srK5STp8RydCm1dK+/41K9e5xeFu23Q==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9359,9 +9272,9 @@
       }
     },
     "node_modules/@wordpress/wordcount": {
-      "version": "4.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.46.0.tgz",
-      "integrity": "sha512-rOIICvsdxI80m3ajd/cxVls2Bc9Vin0x59mDJn8omxlwbuyIAPSAkSgt273m+uIIH6/05mXVIYULfWRFW9K5+w==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.48.0.tgz",
+      "integrity": "sha512-P9xSlfxL0I5nDPUazuekfJ0tkYWnvrqPDO3YOIEsD4LDNKWWxtzYLmHj4GOEYeQZ3KnJ2wu4VPxDAsFj15cMSg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9369,9 +9282,9 @@
       }
     },
     "node_modules/@wordpress/worker-threads": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.6.0.tgz",
-      "integrity": "sha512-ZhKNMpqgJFiGILIvkYom4MJ/82CpZZ0Uj0UhuFmURo8pQQS3ROpp2/WQ9M/wlH1APUVZU2m7pLtkipt49RZosg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.8.0.tgz",
+      "integrity": "sha512-GyXj5tLYH5aon7yIJbqODeGmIowrjAohA2UrEJLU4UKbJdVAWyx9dlqF/bGs3sUKkkldPxYU7Wk2WIATfu0VGQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "comctx": "^1.4.3"
@@ -9379,6 +9292,19 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -9450,6 +9376,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/anser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
+      "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -9524,6 +9457,18 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/append-field": {
       "version": "1.0.0",
@@ -9600,6 +9545,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/assert": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
@@ -9624,9 +9576,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
-      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9741,6 +9693,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz",
+      "integrity": "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-parser": "0.36.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
@@ -9763,6 +9725,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
+      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -9859,9 +9834,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -9883,7 +9858,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -9896,6 +9870,50 @@
       "license": "MIT",
       "dependencies": {
         "wcwidth": "^1.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -10006,6 +10024,36 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -10147,6 +10195,46 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-edge-launcher": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
+      "integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/clean-stack": {
       "version": "3.0.1",
@@ -10370,9 +10458,9 @@
       }
     },
     "node_modules/comctx": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.6.1.tgz",
-      "integrity": "sha512-ZMRGAYASYRdVfEoB7oxH8Nqu5Ay8I+YvAsQni+td0pYV9eww/PrtSFVyvc2JkNQyHXGDknCB4wJfxFYP6fuqZg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.7.4.tgz",
+      "integrity": "sha512-c5j2twNsFePTxuyPuR1x7UhCxu+BaFtUk8S1okJW9/qcy02PN29P3O8dy4XTtyQIgXYRTZinOYPcZJYMAbg4WQ==",
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -10442,6 +10530,91 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/connect/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/connect/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/constant-case": {
@@ -10554,6 +10727,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "license": "BSD-2-Clause",
@@ -10566,6 +10748,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -10849,6 +11042,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -10856,9 +11070,9 @@
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -10996,6 +11210,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.370",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.370.tgz",
+      "integrity": "sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT"
@@ -11081,6 +11302,16 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.0",
       "license": "MIT",
@@ -11164,7 +11395,8 @@
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -11212,48 +11444,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -11504,6 +11694,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -11513,6 +11713,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/express": {
       "version": "5.2.1",
@@ -11566,6 +11773,38 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/external-editor/node_modules/chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg==",
+      "license": "MIT"
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-average-color": {
@@ -11622,9 +11861,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -11633,12 +11872,37 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fb-dotslash": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
+      "integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
+      "license": "(MIT OR Apache-2.0)",
+      "peer": true,
+      "bin": {
+        "dotslash": "bin/dotslash"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bser": "2.1.1"
       }
     },
     "node_modules/fdir": {
@@ -11705,7 +11969,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -11763,6 +12026,13 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
+    },
+    "node_modules/flow-enums-runtime": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
+      "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -11954,6 +12224,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "license": "ISC",
@@ -12108,6 +12388,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/gradient-parser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
@@ -12208,6 +12495,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/hermes-compiler": {
+      "version": "250829098.0.14",
+      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.14.tgz",
+      "integrity": "sha512-5meXwsZxgiqFaJjNzwjzI9IyUkuGGBisu+z9BvQWmGVpjH6nz11hgqkyxe4dl8UAdyIV4lTbz91+Dlnjz0VxqA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
+      "integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
+      "integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.36.0"
       }
     },
     "node_modules/highlight-words-core": {
@@ -12446,6 +12757,22 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "license": "MIT"
@@ -12490,6 +12817,28 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="
     },
+    "node_modules/inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
+    },
     "node_modules/inquirer-search-checkbox": {
       "version": "1.0.0",
       "license": "ISC",
@@ -12498,20 +12847,6 @@
         "figures": "^2.0.0",
         "fuzzy": "^0.1.3",
         "inquirer": "^3.3.0"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/ansi-escapes": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/inquirer-search-checkbox/node_modules/ansi-styles": {
@@ -12536,24 +12871,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-checkbox/node_modules/chardet": {
-      "version": "0.4.2",
-      "license": "MIT"
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/cli-width": {
-      "version": "2.2.1",
-      "license": "ISC"
-    },
     "node_modules/inquirer-search-checkbox/node_modules/color-convert": {
       "version": "1.9.3",
       "license": "MIT",
@@ -12572,18 +12889,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/inquirer-search-checkbox/node_modules/external-editor": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/inquirer-search-checkbox/node_modules/figures": {
       "version": "2.0.0",
       "license": "MIT",
@@ -12597,100 +12902,6 @@
     "node_modules/inquirer-search-checkbox/node_modules/has-flag": {
       "version": "3.0.0",
       "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/inquirer": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/mute-stream": {
-      "version": "0.0.7",
-      "license": "ISC"
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/onetime": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "license": "ISC"
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/string-width": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-checkbox/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
       "engines": {
         "node": ">=4"
       }
@@ -12715,20 +12926,6 @@
         "inquirer": "^3.3.0"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/ansi-escapes": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-list/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/inquirer-search-list/node_modules/ansi-styles": {
       "version": "3.2.1",
       "license": "MIT",
@@ -12751,24 +12948,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/chardet": {
-      "version": "0.4.2",
-      "license": "MIT"
-    },
-    "node_modules/inquirer-search-list/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inquirer-search-list/node_modules/cli-width": {
-      "version": "2.2.1",
-      "license": "ISC"
-    },
     "node_modules/inquirer-search-list/node_modules/color-convert": {
       "version": "1.9.3",
       "license": "MIT",
@@ -12785,18 +12964,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/inquirer-search-list/node_modules/external-editor": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/inquirer-search-list/node_modules/figures": {
@@ -12816,56 +12983,151 @@
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/iconv-lite": {
-      "version": "0.4.24",
+    "node_modules/inquirer-search-list/node_modules/supports-color": {
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "has-flag": "^3.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/inquirer": {
-      "version": "3.3.0",
+    "node_modules/inquirer/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
-      }
-    },
-    "node_modules/inquirer-search-list/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "license": "MIT",
+        "color-convert": "^1.9.0"
+      },
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/mimic-fn": {
-      "version": "1.2.0",
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/mute-stream": {
-      "version": "0.0.7",
+    "node_modules/inquirer/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "license": "ISC"
     },
-    "node_modules/inquirer-search-list/node_modules/onetime": {
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/inquirer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+      "license": "ISC"
+    },
+    "node_modules/inquirer/node_modules/onetime": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^1.0.0"
@@ -12874,8 +13136,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/restore-cursor": {
+    "node_modules/inquirer/node_modules/restore-cursor": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
       "license": "MIT",
       "dependencies": {
         "onetime": "^2.0.0",
@@ -12885,12 +13149,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "license": "ISC"
-    },
-    "node_modules/inquirer-search-list/node_modules/string-width": {
+    "node_modules/inquirer/node_modules/string-width": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "license": "MIT",
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -12900,8 +13162,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/strip-ansi": {
+    "node_modules/inquirer/node_modules/strip-ansi": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^3.0.0"
@@ -12910,8 +13174,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/inquirer-search-list/node_modules/supports-color": {
+    "node_modules/inquirer/node_modules/supports-color": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -12930,6 +13196,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -13198,7 +13474,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -13480,6 +13755,110 @@
         "node": ">=10"
       }
     },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13494,6 +13873,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsc-safe-url": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
+      "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "23.2.0",
@@ -13567,6 +13953,19 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "license": "(MIT OR GPL-3.0-or-later)",
@@ -13601,6 +14000,16 @@
     "node_modules/kuler": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -13639,6 +14048,295 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "debug": "^2.6.9",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -13698,6 +14396,13 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -13817,6 +14522,23 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
@@ -13842,6 +14564,13 @@
       "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
       "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "license": "MIT",
@@ -13850,6 +14579,378 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/metro": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "accepts": "^2.0.0",
+        "ci-info": "^2.0.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.35.0",
+        "image-size": "^1.0.2",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "jsc-safe-url": "^0.2.2",
+        "lodash.throttle": "^4.1.1",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-config": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-file-map": "0.84.4",
+        "metro-resolver": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-symbolicate": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "metro-transform-worker": "0.84.4",
+        "mime-types": "^3.0.1",
+        "nullthrows": "^1.1.1",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
+        "throat": "^5.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "metro": "src/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-babel-transformer": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.35.0",
+        "metro-cache-key": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
+    },
+    "node_modules/metro-cache": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-cache-key": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-config": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "connect": "^3.6.5",
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "yaml": "^2.6.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-core": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "lodash.throttle": "^4.1.1",
+        "metro-resolver": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-file-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-minify-terser": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "terser": "^5.15.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-resolver": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-runtime": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-symbolicate": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-transform-plugins": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-transform-worker": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.84.4",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-minify-terser": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro/node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/metro/node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
+    },
+    "node_modules/metro/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/migration-aem": {
@@ -13871,6 +14972,19 @@
     "node_modules/migration-wordpress": {
       "resolved": "migration-wordpress",
       "link": true
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -14078,15 +15192,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -14112,6 +15227,23 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/nodemon": {
@@ -14186,6 +15318,26 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ob1": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -14711,9 +15863,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -14730,7 +15882,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -14766,9 +15918,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.29.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
-      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -14806,9 +15958,47 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
+    },
+    "node_modules/promise": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -14870,9 +16060,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -14887,6 +16078,16 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -14974,6 +16175,39 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/react-devtools-core": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
+      "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -15006,10 +16240,143 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-native": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.0.tgz",
+      "integrity": "sha512-17ALh/dd6AO4pgOVmOO5Axll5PbErEo3XFyLokyzW6usyi+OShIEPwUW26wLPlhVifgSOIfECCH0WN+0IqtJ1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@react-native/assets-registry": "0.86.0",
+        "@react-native/codegen": "0.86.0",
+        "@react-native/community-cli-plugin": "0.86.0",
+        "@react-native/gradle-plugin": "0.86.0",
+        "@react-native/js-polyfills": "0.86.0",
+        "@react-native/normalize-colors": "0.86.0",
+        "@react-native/virtualized-lists": "0.86.0",
+        "abort-controller": "^3.0.0",
+        "anser": "^1.4.9",
+        "ansi-regex": "^5.0.0",
+        "babel-plugin-syntax-hermes-parser": "0.36.0",
+        "base64-js": "^1.5.1",
+        "commander": "^12.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-compiler": "250829098.0.14",
+        "invariant": "^2.2.4",
+        "memoize-one": "^5.0.0",
+        "metro-runtime": "^0.84.3",
+        "metro-source-map": "^0.84.3",
+        "nullthrows": "^1.1.1",
+        "pretty-format": "^29.7.0",
+        "promise": "^8.3.0",
+        "react-devtools-core": "^6.1.5",
+        "react-refresh": "^0.14.0",
+        "regenerator-runtime": "^0.13.2",
+        "scheduler": "0.27.0",
+        "semver": "^7.1.3",
+        "stacktrace-parser": "^0.1.10",
+        "tinyglobby": "^0.2.15",
+        "whatwg-fetch": "^3.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "react-native": "cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@react-native/jest-preset": "0.86.0",
+        "@types/react": "^19.1.1",
+        "react": "^19.2.3"
+      },
+      "peerDependenciesMeta": {
+        "@react-native/jest-preset": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.0.tgz",
+      "integrity": "sha512-4/ZLXdf/OSpPDVO0AsQ1SJdRIzt5t9BNQ46QwGgxvX7/cirYR5k8KXctNGGgW8lQo2gZChEfY2zFCZg9nM/jiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.2.0",
+        "react": "*",
+        "react-native": "0.86.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/react-native/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-native/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
       "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -15169,6 +16536,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "license": "MIT",
@@ -15226,9 +16600,9 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -15269,10 +16643,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "license": "ISC"
-    },
     "node_modules/rimraf": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
@@ -15292,49 +16662,38 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -15492,7 +16851,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15533,6 +16894,16 @@
     },
     "node_modules/seq-queue": {
       "version": "0.0.5"
+    },
+    "node_modules/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/serve-static": {
       "version": "2.2.0",
@@ -15614,6 +16985,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/short-uuid": {
@@ -15909,6 +17293,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/simple-html-tokenizer": {
       "version": "0.5.11",
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
@@ -16058,6 +17448,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -16085,6 +17496,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/stacktrace-parser/node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
@@ -16093,9 +17534,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -16243,16 +17684,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -16343,6 +17787,25 @@
         "node": ">=18.13.0"
       }
     },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "license": "MIT"
@@ -16354,6 +17817,13 @@
       "engines": {
         "node": ">=0.2.6"
       }
+    },
+    "node_modules/throat": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -16383,11 +17853,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -16397,9 +17869,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16407,17 +17879,25 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -16761,7 +18241,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unique-string": {
@@ -16787,6 +18266,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/upper-case": {
@@ -16914,6 +18424,16 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
@@ -16941,18 +18461,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -16968,9 +18487,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -16983,13 +18503,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -17016,31 +18539,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -17056,12 +18579,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -17082,6 +18608,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -17090,8 +18622,25 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vlq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+      "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -17103,6 +18652,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/wasm-vips": {
@@ -17149,6 +18708,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
@@ -17385,9 +18951,10 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17484,6 +19051,29 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/upload-api/package-lock.json
+++ b/upload-api/package-lock.json
@@ -11070,9 +11070,9 @@
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -18032,16 +18032,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/tslib": {

--- a/upload-api/package.json
+++ b/upload-api/package.json
@@ -90,7 +90,7 @@
     "@tootallnate/once": ">=3.0.1",
     "fast-xml-parser": ">=5.3.8",
     "@wordpress/block-editor": {
-      "diff": "4.0.2"
+      "diff": "4.0.4"
     },
     "qs": ">=6.14.2"
   }

--- a/upload-api/package.json
+++ b/upload-api/package.json
@@ -89,7 +89,9 @@
     "rollup": ">=4.59.0",
     "@tootallnate/once": ">=3.0.1",
     "fast-xml-parser": ">=5.3.8",
-    "diff": ">=5.2.2",
+    "@wordpress/block-editor": {
+      "diff": "4.0.2"
+    },
     "qs": ">=6.14.2"
   }
 }

--- a/upload-api/src/helper/index.ts
+++ b/upload-api/src/helper/index.ts
@@ -210,14 +210,43 @@ function deleteFolderSync(folderPath: string): void {
   }
 }
 
-async function updateConfigFile(filePath?: string): Promise<any | undefined> {
+interface MySQLDetails {
+  host?: string;
+  database?: string;
+  user?: string;
+}
+
+async function updateConfigFile(
+  filePath?: string,
+  mysqlDetails?: MySQLDetails
+): Promise<any | undefined> {
   try {
     const { src: configFilePath } = getConfigFilePaths();
     const config: any = JSON.parse(await fs.promises.readFile(configFilePath, 'utf8'));
 
+    const isDrupal = String(config?.cmsType).toLowerCase() === 'drupal';
+
+    // For drupal the source is a MySQL DB. Persist the host/database/user the user
+    // entered in the UI ("Check Connection") into config.mysql, preserving the other
+    // mysql fields (e.g. port, password).
+    if (isDrupal && mysqlDetails && typeof mysqlDetails === 'object') {
+      const { host, database, user } = mysqlDetails;
+      config.mysql = {
+        ...config.mysql,
+        ...(host?.trim() ? { host: host.trim() } : {}),
+        ...(database?.trim() ? { database: database.trim() } : {}),
+        ...(user?.trim() ? { user: user.trim() } : {})
+      };
+    }
+
     // If filePath is provided and not empty, update the config file
     if (filePath && typeof filePath === 'string' && filePath.trim() !== '') {
-      const resolvedFilePath = path.resolve(filePath.trim());
+      const trimmed = filePath.trim();
+      // "sql" is a sentinel for MySQL validation (routes/index.ts), not a filesystem path.
+      // For drupal the source is a MySQL DB, so localPath must stay "sql" rather than a
+      // resolved path. path.resolve("sql") would incorrectly become <cwd>/sql and break SQL mode.
+      const resolvedFilePath =
+        isDrupal || trimmed.toLowerCase() === 'sql' ? 'sql' : path.resolve(trimmed);
 
       const updatedConfig = {
         ...config,
@@ -228,6 +257,12 @@ async function updateConfigFile(filePath?: string): Promise<any | undefined> {
       await fs.promises.writeFile(configFilePath, configContent, 'utf8');
 
       return updatedConfig;
+    }
+
+    // No filePath, but drupal mysql details changed — persist them and return updated config.
+    if (isDrupal && mysqlDetails && typeof mysqlDetails === 'object') {
+      const configContent = JSON.stringify(config, null, 2);
+      await fs.promises.writeFile(configFilePath, configContent, 'utf8');
     }
 
     return config;

--- a/upload-api/src/helper/index.ts
+++ b/upload-api/src/helper/index.ts
@@ -226,11 +226,16 @@ async function updateConfigFile(
 
     const isDrupal = String(config?.cmsType).toLowerCase() === 'drupal';
 
+    // Only treat mysqlDetails as meaningful when at least one field is a non-empty string,
+    // so empty/undefined payloads don't trigger an unnecessary config write below.
+    const { host, database, user } = mysqlDetails ?? {};
+    const hasMysqlDetails =
+      isDrupal && !!(host?.trim() || database?.trim() || user?.trim());
+
     // For drupal the source is a MySQL DB. Persist the host/database/user the user
     // entered in the UI ("Check Connection") into config.mysql, preserving the other
     // mysql fields (e.g. port, password).
-    if (isDrupal && mysqlDetails && typeof mysqlDetails === 'object') {
-      const { host, database, user } = mysqlDetails;
+    if (hasMysqlDetails) {
       config.mysql = {
         ...config.mysql,
         ...(host?.trim() ? { host: host.trim() } : {}),
@@ -260,7 +265,7 @@ async function updateConfigFile(
     }
 
     // No filePath, but drupal mysql details changed — persist them and return updated config.
-    if (isDrupal && mysqlDetails && typeof mysqlDetails === 'object') {
+    if (hasMysqlDetails) {
       const configContent = JSON.stringify(config, null, 2);
       await fs.promises.writeFile(configFilePath, configContent, 'utf8');
     }

--- a/upload-api/src/routes/index.ts
+++ b/upload-api/src/routes/index.ts
@@ -270,7 +270,19 @@ router.get(
       const affix: string = sanitizeId(req?.headers?.affix ?? 'csm');
       const rawFilePath = Array.isArray(req?.headers?.file_path) ? req?.headers?.file_path?.[0] : req?.headers?.file_path;
       const filePath: string | undefined = rawFilePath && typeof rawFilePath === 'string' && rawFilePath.trim() !== '' ? rawFilePath.trim() : undefined;
-      const config = await updateConfigFile(filePath);
+
+      // MySQL connection details from the UI ("Check Connection"); only used for drupal.
+      const readHeader = (value: string | string[] | undefined): string | undefined => {
+        const raw = Array.isArray(value) ? value[0] : value;
+        return raw && typeof raw === 'string' && raw.trim() !== '' ? raw.trim() : undefined;
+      };
+      const mysqlDetails = {
+        host: readHeader(req?.headers?.mysql_host),
+        database: readHeader(req?.headers?.mysql_database),
+        user: readHeader(req?.headers?.mysql_user)
+      };
+
+      const config = await updateConfigFile(filePath, mysqlDetails);
       if (!config) {
         logger.error('Failed to load application config');
         return res.status(500).json({

--- a/upload-api/tests/unit/routes/index.routes.test.ts
+++ b/upload-api/tests/unit/routes/index.routes.test.ts
@@ -236,6 +236,86 @@ describe('routes/index', () => {
     });
   });
 
+  describe('GET /validator — MySQL header parsing', () => {
+    it('should parse mysql_* headers and pass trimmed mysqlDetails to updateConfigFile', async () => {
+      mockConfig.localPath = 'sql';
+      mockHandleFileProcessing.mockResolvedValue({ status: 200, message: 'OK', file_details: {} });
+      const { updateConfigFile } = await import('../../../src/helper');
+
+      const handler = getHandler(router, 'get', '/validator');
+      const res = mockRes();
+      await handler(
+        mockReq({
+          headers: {
+            projectid: 'proj-1',
+            app_token: 'tk',
+            affix: 'csm',
+            file_path: 'sql',
+            mysql_host: '  127.0.0.1  ',
+            mysql_database: '  mydb  ',
+            mysql_user: '  root  ',
+          },
+        }),
+        res
+      );
+
+      expect(updateConfigFile).toHaveBeenCalledWith('sql', {
+        host: '127.0.0.1',
+        database: 'mydb',
+        user: 'root',
+      });
+    });
+
+    it('should use the first element when mysql_* headers are arrays', async () => {
+      mockConfig.localPath = 'sql';
+      mockHandleFileProcessing.mockResolvedValue({ status: 200, message: 'OK', file_details: {} });
+      const { updateConfigFile } = await import('../../../src/helper');
+
+      const handler = getHandler(router, 'get', '/validator');
+      const res = mockRes();
+      await handler(
+        mockReq({
+          headers: {
+            projectid: 'proj-1',
+            app_token: 'tk',
+            affix: 'csm',
+            mysql_host: ['10.0.0.1', '10.0.0.2'],
+            mysql_database: ['firstdb', 'seconddb'],
+            mysql_user: ['admin', 'guest'],
+          },
+        }),
+        res
+      );
+
+      expect(updateConfigFile).toHaveBeenCalledWith(undefined, {
+        host: '10.0.0.1',
+        database: 'firstdb',
+        user: 'admin',
+      });
+    });
+
+    it('should pass undefined mysql fields when headers are missing or blank', async () => {
+      mockConfig.localPath = 'sql';
+      mockHandleFileProcessing.mockResolvedValue({ status: 200, message: 'OK', file_details: {} });
+      const { updateConfigFile } = await import('../../../src/helper');
+
+      const handler = getHandler(router, 'get', '/validator');
+      const res = mockRes();
+      await handler(
+        mockReq({
+          headers: { projectid: 'proj-1', app_token: 'tk', affix: 'csm', mysql_host: '   ' },
+        }),
+        res
+      );
+
+      expect(updateConfigFile).toHaveBeenCalledWith(undefined, {
+        host: undefined,
+        database: undefined,
+        user: undefined,
+      });
+    });
+  });
+
   describe('GET /validator — directory path', () => {
     it('should handle directory and call mapper on 200', async () => {
       mockConfig.localPath = '/tmp/content-dir';


### PR DESCRIPTION
## 🔗 Jira Ticket

. [CMG-993](https://contentstack.atlassian.net/browse/CMG-993) 
· [CMG-994](https://contentstack.atlassian.net/browse/CMG-994) 
· [CMG-995](https://contentstack.atlassian.net/browse/CMG-995) 
· [CMG-996](https://contentstack.atlassian.net/browse/CMG-996)

---

## 📋 PR Type

- [x] ✨ Feature
- [x] 🐛 Bug Fix

---

## 📝 Description

### What changed?

**Feature — Drupal MySQL connection editing**
- LoadUploadFile: made Host/Database/User editable for SQL format, mirroring the local-path edit flow
- upload.service / fileValidation: forward mysql details as `mysql_host`/`mysql_database`/`mysql_user` headers for drupal validation
- upload-api: persist UI-entered mysql details into `config.mysql`; keep `localPath` as the `"sql"` sentinel instead of resolving it to a filesystem path

**Bug Fix — content mapper & migration CTA**
- ContentMapper: update the content type status icon on entry selection (Updated/green vs Mapped/blue); hide the Save footer when there are no fields/entries; fix the empty-state ("No Records Found") layout to fill the viewport
- MigrationFlowHeader: disable the CTA only while migration is actively in progress, re-enabling as "Restart Migration" once completed

### Why?

Drupal sources connect via MySQL rather than a file, but the connection details were read-only, so users couldn't correct them across iterations. The content mapper status icons and Save footer didn't reflect actual entry/field state, and the migration CTA stayed disabled even after completion.

---

## 🧩 Affected Areas

- [ ] `api` — Node.js backend
- [x] `ui` — React frontend
- [x] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

1. Start a Drupal migration; on the upload step, edit the Host/Database/User fields and run validation — confirm the values persist and reach `config.mysql`.
2. On the Content Mapper step, select/deselect entries for a content type and save — confirm the status icon turns green (Updated) when selected, blue (Mapped) when cleared.
3. Open a content type with no fields and an entry view with no records — confirm the Save footer is hidden and the empty state fills the viewport.
4. Start a migration — confirm the header CTA is disabled while running and re-enables as "Restart Migration" once complete.

**Expected result:** Drupal MySQL details are editable and persisted; content mapper icons/footer reflect real state; CTA only disables during active migration.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

-

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `feature/`, `bugfix/`, or `hotfix/` + 5–30 lowercase chars
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added
- [ ] No sensitive credentials or secrets committed
- [x] Existing tests pass locally (`npm test`)
- [x] New tests written (or not applicable — explain why)
- [] `README.md` / docs updated if behaviour changed
- [x] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

- Focus on [upload-api/src/helper/index.ts](upload-api/src/helper/index.ts) — `updateConfigFile` now branches on drupal to persist `config.mysql` and to keep `localPath` as `"sql"`. Confirm non-drupal flows are unaffected.
- The `package.json` override swapped the top-level `diff` constraint for a nested `@wordpress/block-editor` override pinning `diff@4.0.4` — please confirm that's intended.

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) 
· [Issues](https://github.com/contentstack/migration-v2/issues)
