### PR TITLE
feat: Implement delta migration support for content mapping and entry…

### DIFF
--- a/api/src/constants/index.ts
+++ b/api/src/constants/index.ts
@@ -179,6 +179,24 @@ export const STEPPER_STEPS: any = {
   TESTING: 4,
   MIGRATION: 5,
 };
+
+// Delta migration (iteration > 1) inserts a "Map Entry" step after Content Mapping, shifting
+// Testing and Migration down by one. Iteration 1 keeps the original 5-step numbering.
+export const DELTA_STEPPER_STEPS: any = {
+  LEGACY_CMS: 1,
+  DESTINATION_STACK: 2,
+  CONTENT_MAPPING: 3,
+  MAP_ENTRY: 4,
+  TESTING: 5,
+  MIGRATION: 6,
+};
+
+/**
+ * Returns the step-number map for a given iteration: the 6-step delta layout (with Map Entry)
+ * from iteration 2 onwards, or the original 5-step layout for iteration 1.
+ */
+export const getStepperSteps = (iteration?: number) =>
+  (iteration ?? 1) > 1 ? DELTA_STEPPER_STEPS : STEPPER_STEPS;
 export const PREDEFINED_STATUS = [
   'Draft',
   'Ready',

--- a/api/src/services/contentMapper.service.ts
+++ b/api/src/services/contentMapper.service.ts
@@ -326,6 +326,39 @@ const putTestData = async (req: Request) => {
 };
 
 /**
+ * Splits the current iteration's content types into "new" vs "old" relative to the
+ * previous iteration, by comparing on `otherCmsUid`.
+ * - mode 'new': content types NOT present in the previous iteration (mapped for the first time).
+ * - mode 'old': content types already present in the previous iteration (already migrated) AND
+ *   that have at least one entry mapping — Step 4 (Map Entry) can only map entries for content
+ *   types that actually have entries, so types with an empty entryMapping are excluded.
+ * Used on delta migrations (iteration > 1) so Step 3 (Map Content Fields) only re-maps new
+ * types and Step 4 (Map Entry) only maps entries of already-migrated types that have entries.
+ * @param currentCts - Content types of the current iteration.
+ * @param prevCts - Content types of the previous iteration.
+ * @param mode - 'new' or 'old'.
+ * @returns The filtered subset of `currentCts`.
+ */
+const filterContentTypesByIteration = (
+  currentCts: ContentTypesMapper[],
+  prevCts: ContentTypesMapper[],
+  mode: 'new' | 'old',
+): ContentTypesMapper[] => {
+  const prevUids = new Set(
+    (prevCts ?? [])
+      .map((ct) => ct?.otherCmsUid)
+      .filter((uid): uid is string => Boolean(uid)),
+  );
+  return (currentCts ?? []).filter((ct) => {
+    if (mode === 'old') {
+      const hasEntries = Array.isArray(ct?.entryMapping) && ct.entryMapping.length > 0;
+      return prevUids.has(ct?.otherCmsUid) && hasEntries;
+    }
+    return !prevUids.has(ct?.otherCmsUid);
+  });
+};
+
+/**
  * Retrieves the content types based on the provided request parameters.
  * @param req - The request object containing the parameters.
  * @returns An object containing the total count and the array of content types.
@@ -336,6 +369,9 @@ const getContentTypes = async (req: Request) => {
   const skip: any = req?.params?.skip;
   const limit: any = req?.params?.limit;
   const search: string = req?.params?.searchText?.toLowerCase();
+  // Delta migration: 'new' (default) → first-time content types for Step 3 (field mapping);
+  // 'old' → already-migrated content types for Step 4 (entry mapping). Only applied when iteration > 1.
+  const filter: 'new' | 'old' = req?.query?.filter === 'old' ? 'old' : 'new';
 
   let result: any = [];
   let totalCount = 0;
@@ -385,6 +421,42 @@ const getContentTypes = async (req: Request) => {
     logger.info(
       `📦 [getContentTypes] Found ${content_mapper.length} content types`,
     );
+
+    // Delta migration: from iteration 2 onwards, split content types into new vs old
+    // relative to the previous iteration so Step 3 (field mapping) shows only new types
+    // and Step 4 (entry mapping) shows only already-migrated types. Iteration 1 is untouched.
+    if (iteration > 1) {
+      const PrevContentTypesMapperModelLowdb = getContentTypesMapperDb(projectId, iteration - 1);
+      await PrevContentTypesMapperModelLowdb.read();
+      const prevContentMapper =
+        PrevContentTypesMapperModelLowdb.chain.get('ContentTypesMappers').value() ?? [];
+
+      const filtered = filterContentTypesByIteration(content_mapper, prevContentMapper, filter);
+      content_mapper.length = 0;
+      content_mapper.push(...filtered);
+
+      // For Step 4 (Map Entry), derive each content type's status from the entry mapper so the
+      // list icon reflects persisted state on load: 'Updated' (2/green) when the content type has
+      // at least one entry marked isUpdate, otherwise 'Mapped' (1/blue). Without this the UI would
+      // show every type as blue after a reload until the user opens it.
+      if (filter === 'old') {
+        const EntryMapperModelLowdb = getEntryMapperDb(projectId, iteration);
+        await EntryMapperModelLowdb.read();
+        const entryMapperItems = EntryMapperModelLowdb.chain.get('entry_mapper').value() ?? [];
+        const updatedContentTypeIds = new Set(
+          entryMapperItems
+            .filter((entry: any) => entry?.isUpdate)
+            .map((entry: any) => entry?.contentTypeId),
+        );
+        content_mapper.forEach((ct: any) => {
+          ct.status = updatedContentTypeIds.has(ct?.id) ? 2 : 1;
+        });
+      }
+
+      logger.info(
+        `📦 [getContentTypes] iteration ${iteration}, filter '${filter}' → ${content_mapper.length} content types`,
+      );
+    }
 
     if (!isEmpty(content_mapper)) {
       if (search) {

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -14,7 +14,7 @@ import {
   HTTP_TEXTS,
   HTTP_CODES,
   LOCALE_MAPPER,
-  STEPPER_STEPS,
+  getStepperSteps,
   CMS,
   GET_AUDIT_DATA,
   MIGRATION_DATA_CONFIG,
@@ -151,7 +151,9 @@ const createTestStack = async (req: Request): Promise<LoginServiceType> => {
       
 
       ProjectModelLowdb.update((data: any) => {
-        data.projects[index].current_step = STEPPER_STEPS['TESTING'];
+        // Delta migration: Testing is step 5 on iteration 2+ (4 on iteration 1).
+        data.projects[index].current_step =
+          getStepperSteps(data.projects[index]?.iteration)['TESTING'];
         data.projects[index].current_test_stack_id = res?.data?.stack?.api_key;
         data.projects[index].test_stacks.push({
           stackUid: res?.data?.stack?.api_key,

--- a/api/src/services/projects.service.ts
+++ b/api/src/services/projects.service.ts
@@ -15,6 +15,7 @@ import {
   HTTP_CODES,
   STEPPER_STEPS,
   NEW_PROJECT_STATUS,
+  getStepperSteps,
 } from "../constants/index.js";
 import { config } from "../config/index.js";
 import { getLogMessage, isEmpty, safePromise } from "../utils/index.js";
@@ -934,6 +935,11 @@ const updateCurrentStep = async (req: Request) => {
     const isStepCompleted =
       project?.legacy_cms?.cms && project?.legacy_cms?.file_format;
 
+    // Delta migration: from iteration 2 onwards the flow has an extra "Map Entry" step (step 4),
+    // shifting Testing → 5 and Migration → 6. Resolve the step-number map for this project's
+    // iteration so the state machine progresses through the correct steps.
+    const steps = getStepperSteps(project?.iteration);
+
     switch (project.current_step) {
       case STEPPER_STEPS.LEGACY_CMS: {
         if (project.status !== NEW_PROJECT_STATUS[0] || !isStepCompleted) {
@@ -998,7 +1004,7 @@ const updateCurrentStep = async (req: Request) => {
         });
         break;
       }
-      case STEPPER_STEPS.CONTENT_MAPPING: {
+      case steps.CONTENT_MAPPING: {
         if (
           project.status === NEW_PROJECT_STATUS[0] ||
           !isStepCompleted ||
@@ -1023,13 +1029,31 @@ const updateCurrentStep = async (req: Request) => {
           ) {
             throw new NotFoundError(HTTP_TEXTS.PROJECT_NOT_FOUND);
           }
-          data.projects[projectIndex].current_step = STEPPER_STEPS.TESTING;
+          // Delta iteration: Content Mapping → Map Entry (step 4). Iteration 1: → Testing (step 4).
+          data.projects[projectIndex].current_step =
+            steps.MAP_ENTRY ?? steps.TESTING;
           data.projects[projectIndex].status = NEW_PROJECT_STATUS[4];
           data.projects[projectIndex].updated_at = new Date().toISOString();
         });
         break;
       }
-      case STEPPER_STEPS.TESTING: {
+      // Map Entry → Testing. Only reachable on delta iterations (step exists from iteration 2).
+      case steps.MAP_ENTRY: {
+        await ProjectModelLowdb.update((data: any) => {
+          if (
+            !data?.projects ||
+            !Array.isArray(data.projects) ||
+            !data.projects[projectIndex]
+          ) {
+            throw new NotFoundError(HTTP_TEXTS.PROJECT_NOT_FOUND);
+          }
+          data.projects[projectIndex].current_step = steps.TESTING;
+          data.projects[projectIndex].status = NEW_PROJECT_STATUS[4];
+          data.projects[projectIndex].updated_at = new Date().toISOString();
+        });
+        break;
+      }
+      case steps.TESTING: {
         if (
           project.status === NEW_PROJECT_STATUS[0] ||
           !isStepCompleted ||
@@ -1056,13 +1080,13 @@ const updateCurrentStep = async (req: Request) => {
           ) {
             throw new NotFoundError(HTTP_TEXTS.PROJECT_NOT_FOUND);
           }
-          data.projects[projectIndex].current_step = STEPPER_STEPS.MIGRATION;
+          data.projects[projectIndex].current_step = steps.MIGRATION;
           data.projects[projectIndex].status = NEW_PROJECT_STATUS[4];
           data.projects[projectIndex].updated_at = new Date().toISOString();
         });
         break;
       }
-      case STEPPER_STEPS.MIGRATION: {
+      case steps.MIGRATION: {
         if (
           project.status === NEW_PROJECT_STATUS[0] ||
           !isStepCompleted ||
@@ -1089,7 +1113,7 @@ const updateCurrentStep = async (req: Request) => {
           ) {
             throw new NotFoundError(HTTP_TEXTS.PROJECT_NOT_FOUND);
           }
-          data.projects[projectIndex].current_step = STEPPER_STEPS.MIGRATION;
+          data.projects[projectIndex].current_step = steps.MIGRATION;
           data.projects[projectIndex].status = NEW_PROJECT_STATUS[5];
           data.projects[projectIndex].updated_at = new Date().toISOString();
         });
@@ -1575,7 +1599,8 @@ const getMigratedStacks = async (req: Request) => {
         (project: any) =>
           project != null &&
           project?.status === 5 &&
-          project?.current_step === 5 &&
+          // Project is on its final Execute step (6 on delta iterations, 5 otherwise).
+          project?.current_step === getStepperSteps(project?.iteration).MIGRATION &&
           project?.destination_stack_id
       )
       .map((project: any) => project.destination_stack_id)

--- a/api/src/services/runCli.service.ts
+++ b/api/src/services/runCli.service.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import { spawn } from 'child_process';
 import { v4 } from 'uuid';
 import { copyDirectory, createDirectoryAndFile } from '../utils/index.js';
-import { CS_REGIONS, MIGRATION_DATA_CONFIG, DATABASE_FILES } from '../constants/index.js';
+import { CS_REGIONS, MIGRATION_DATA_CONFIG, DATABASE_FILES, getStepperSteps } from '../constants/index.js';
 import ProjectModelLowdb from '../models/project-lowdb.js';
 import AuthenticationModel from '../models/authentication.js';
 // import watchLogs from '../utils/watch.utils.js';
@@ -317,7 +317,9 @@ export const runCli = async (
           true;
         ProjectModelLowdb.data.projects[projectIndex].isMigrationStarted =
           false;
-        ProjectModelLowdb.data.projects[projectIndex].current_step = 5;
+        // Migration completed → land on the final Execute step (6 on delta iterations, 5 otherwise).
+        ProjectModelLowdb.data.projects[projectIndex].current_step =
+          getStepperSteps(ProjectModelLowdb.data.projects[projectIndex]?.iteration).MIGRATION;
         ProjectModelLowdb.data.projects[projectIndex].status = 5;
         await ProjectModelLowdb.write();
       }

--- a/api/src/utils/entry-update-script.cjs
+++ b/api/src/utils/entry-update-script.cjs
@@ -153,7 +153,6 @@ module.exports = async ({
                                 if (updateData && entry) {
                                     for (const field of Object.keys(updateData)) {
                                         if (isAssetField(updateData[field])) {
-                                            console.info('field is asset field');
                                             updateData[field] = resolveAssetField(
                                                 field,
                                                 entryUid,

--- a/api/src/utils/entry-update.utils.ts
+++ b/api/src/utils/entry-update.utils.ts
@@ -75,10 +75,18 @@ export const removeEntriesFromDatabase = async (projectId: string, loggerPath?: 
         entryMapperItems.map((item: { otherCmsEntryUid: string }) => item?.otherCmsEntryUid)
     );
 
+    // Entries that already exist in Contentstack (have a contentstackEntryUid). These are removed
+    // from the import data so they are NOT re-created — regardless of isUpdate.
+    const csUidMap = new Map<string, string>();
+    // Subset of the above marked isUpdate → collected into the update config so they get updated
+    // in Contentstack. Existing entries that are NOT isUpdate are simply left untouched.
     const updateUidMap = new Map<string, string>();
     for (const item of entryMapperItems) {
-        if (item.isUpdate) {
-            updateUidMap.set(item?.otherCmsEntryUid, item?.contentstackEntryUid);
+        if (item?.contentstackEntryUid) {
+            csUidMap.set(item?.otherCmsEntryUid, item?.contentstackEntryUid);
+            if (item?.isUpdate) {
+                updateUidMap.set(item?.otherCmsEntryUid, item?.contentstackEntryUid);
+            }
         }
     }
 
@@ -144,8 +152,17 @@ export const removeEntriesFromDatabase = async (projectId: string, loggerPath?: 
                 let modified = false;
                 for (const key of Object?.keys(data)) {
                     if (sitecoreUids.has(key)) {
-                        const csEntryUid = updateUidMap.get(key);
-                        if (csEntryUid) {
+                        const csEntryUid = csUidMap.get(key);
+                        // No Contentstack entry uid → this entry was never migrated, so leave it in
+                        // the import data to be CREATED this iteration. Deleting it would silently
+                        // drop the entry (data loss).
+                        if (!csEntryUid) {
+                            continue;
+                        }
+
+                        // Entry already exists in Contentstack. If it's marked isUpdate, collect it
+                        // into the update config so it gets updated; otherwise it's left as-is.
+                        if (updateUidMap.has(key)) {
                             const entryData = { ...data[key] };
                             delete entryData?.uid;
 
@@ -157,10 +174,11 @@ export const removeEntriesFromDatabase = async (projectId: string, loggerPath?: 
                             writeLogEntry(`Entry "${key}" has been prepared for update in Contentstack as "${csEntryUid}"`, "removeEntriesFromDatabase", loggerPath);
                         }
 
+                        // Existing entry → remove from import data so it is NOT re-created.
                         delete data[key];
                         modified = true;
                         writeLogEntry(`Removed entry "${key}" from ${filePath}`, "removeEntriesFromDatabase", loggerPath);
-                        writeLogEntry(`Entry "${key}" has been removed from migration data (will be updated instead of created)`, "removeEntriesFromDatabase", loggerPath);
+                        writeLogEntry(`Entry "${key}" has been removed from migration data (exists in Contentstack)`, "removeEntriesFromDatabase", loggerPath);
                     }
                 }
 

--- a/api/tests/unit/services/updateEntryCli.service.test.ts
+++ b/api/tests/unit/services/updateEntryCli.service.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+const {
+  mockSpawn,
+  mockAppendFileSync,
+  mockAuthRead,
+  mockAuthChainGet,
+  mockSetLogFilePath,
+  mockSetOAuthConfig,
+  mockSetBasicAuthConfig,
+} = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+  mockAppendFileSync: vi.fn(),
+  mockAuthRead: vi.fn(),
+  mockAuthChainGet: vi.fn(),
+  mockSetLogFilePath: vi.fn(),
+  mockSetOAuthConfig: vi.fn(),
+  mockSetBasicAuthConfig: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+vi.mock('fs', () => ({
+  default: { appendFileSync: mockAppendFileSync },
+  appendFileSync: mockAppendFileSync,
+}));
+
+vi.mock('../../../src/models/authentication.js', () => ({
+  default: {
+    read: mockAuthRead,
+    chain: { get: mockAuthChainGet },
+  },
+}));
+
+vi.mock('../../../src/server.js', () => ({
+  setLogFilePath: mockSetLogFilePath,
+}));
+
+vi.mock('../../../src/utils/config-handler.util.js', () => ({
+  setOAuthConfig: mockSetOAuthConfig,
+  setBasicAuthConfig: mockSetBasicAuthConfig,
+}));
+
+import { updateEntryCli, utilsUpdateCli } from '../../../src/services/updateEntryCli.service.js';
+
+/**
+ * Builds a fake child process whose close event fires with the given exit code
+ * on the next tick, optionally emitting stdout/stderr data first.
+ */
+const makeChild = (exitCode = 0, stdout = '', stderr = '') => {
+  const child: any = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  queueMicrotask(() => {
+    if (stdout) child.stdout.emit('data', Buffer.from(stdout));
+    if (stderr) child.stderr.emit('data', Buffer.from(stderr));
+    child.emit('close', exitCode);
+  });
+  return child;
+};
+
+const setUser = (user: any) => {
+  mockAuthChainGet.mockReturnValue({
+    find: vi.fn().mockReturnValue({ value: vi.fn().mockReturnValue(user) }),
+  });
+};
+
+describe('updateEntryCli.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthRead.mockResolvedValue(undefined);
+    mockSetLogFilePath.mockResolvedValue(undefined);
+    setUser({ email: 'u@x.com', authtoken: 'tok', region: 'NA', user_id: 'u1' });
+    mockSpawn.mockImplementation(() => makeChild(0));
+  });
+
+  it('exposes updateEntryCli via the utilsUpdateCli object', () => {
+    expect(utilsUpdateCli.updateEntryCli).toBe(updateEntryCli);
+  });
+
+  it('runs both CLI commands and logs success for a basic-auth user', async () => {
+    await updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json');
+
+    // config:set:region + cm:stacks:migration = 2 spawned commands
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSetBasicAuthConfig).toHaveBeenCalled();
+    expect(mockSetOAuthConfig).not.toHaveBeenCalled();
+    // a success completion line is written
+    const written = mockAppendFileSync.mock.calls.map((c) => String(c[1]));
+    expect(written.some((l) => l.includes('Entry Update Process Completed'))).toBe(true);
+  });
+
+  it('uses OAuth config when the user has an access token', async () => {
+    setUser({ email: 'u@x.com', access_token: 'oauth', region: 'NA', user_id: 'u1' });
+    await updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json');
+
+    expect(mockSetOAuthConfig).toHaveBeenCalled();
+    expect(mockSetBasicAuthConfig).not.toHaveBeenCalled();
+  });
+
+  it('logs and returns early when stack_api_key is missing (no migration command)', async () => {
+    await updateEntryCli('NA', 'u1', '', '/tmp/log', '/tmp/config.json');
+
+    // only the first command (config:set:region) runs; migration is skipped
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const written = mockAppendFileSync.mock.calls.map((c) => String(c[1]));
+    expect(written.some((l) => l.includes('stack API key missing'))).toBe(true);
+  });
+
+  it('catches errors when the user has no authentication token', async () => {
+    setUser({ email: 'u@x.com', region: 'NA', user_id: 'u1' }); // no authtoken/access_token
+    await updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json');
+
+    // first command runs, then the missing-auth throw is caught and logged
+    const written = mockAppendFileSync.mock.calls.map((c) => String(c[1]));
+    expect(written.some((l) => l.includes('Failed to update entries'))).toBe(true);
+  });
+
+  it('classifies stdout/stderr output and writes log entries with correct levels', async () => {
+    mockSpawn
+      .mockImplementationOnce(() => makeChild(0, 'Operation failed: not found\n', 'boom\n'))
+      .mockImplementationOnce(() => makeChild(0, 'all good\n'));
+
+    await updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json');
+
+    const entries = mockAppendFileSync.mock.calls
+      .map((c) => {
+        try {
+          return JSON.parse(String(c[1]).trim());
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+    // stdout containing "failed"/"not found" -> error level
+    expect(entries.some((e) => e.level === 'error' && e.message.includes('Operation failed'))).toBe(true);
+    // stderr always logged at error level
+    expect(entries.some((e) => e.level === 'error' && e.message === 'boom')).toBe(true);
+    // benign stdout -> info level
+    expect(entries.some((e) => e.level === 'info' && e.message === 'all good')).toBe(true);
+  });
+
+  it('rejects/handles a non-zero exit code from a spawned command', async () => {
+    mockSpawn.mockImplementationOnce(() => makeChild(1)); // first command fails
+
+    await updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json');
+
+    const entries = mockAppendFileSync.mock.calls
+      .map((c) => {
+        try {
+          return JSON.parse(String(c[1]).trim());
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+    expect(entries.some((e) => e.message?.includes('Command failed with exit code 1'))).toBe(true);
+    // the failed command bubbles into the catch block
+    const written = mockAppendFileSync.mock.calls.map((c) => String(c[1]));
+    expect(written.some((l) => l.includes('Failed to update entries'))).toBe(true);
+  });
+
+  it('maps a warning in stdout to warn level', async () => {
+    mockSpawn
+      .mockImplementationOnce(() => makeChild(0, 'this is a warning message\n'))
+      .mockImplementationOnce(() => makeChild(0));
+
+    await updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json');
+
+    const entries = mockAppendFileSync.mock.calls
+      .map((c) => {
+        try {
+          return JSON.parse(String(c[1]).trim());
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+    expect(entries.some((e) => e.level === 'warn')).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1441,9 +1441,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.0.0.tgz",
+      "integrity": "sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "tar": ">=7.5.8",
     "@tootallnate/once": ">=3.0.1",
     "fast-xml-parser": ">=5.3.8",
-    "diff": ">=5.2.2"
+    "diff": ">=5.2.2",
+    "fast-uri": ">=3.1.2"
   },
   "husky": {
     "hooks": {

--- a/ui/src/cmsData/migrationSteps.json
+++ b/ui/src/cmsData/migrationSteps.json
@@ -173,16 +173,22 @@
       }
     },
     {
+      "map_entry": {
+        "step_title": "Map Entry",
+        "step_number": 4
+      }
+    },
+    {
       "test_migration": {
         "step_title": "Test Migration",
-        "step_number": 4
+        "step_number": 5
       }
     },
     {
       "migration_execution": {
         "step_title": "Migration Execution",
         "_metadata": { "uid": "csd1b57ee4b93373fb" },
-        "step_number": 5,
+        "step_number": 6,
         "migration_execution": [
           { "uid": "blt875421bb12019625", "_content_type_uid": "migration_execution" }
         ]
@@ -224,8 +230,15 @@
       "group_name": "Layout"
     },
     {
-      "flow_id": "testMigration",
+      "flow_id": "mapEntry",
       "name": 4,
+      "title": "Map Entry",
+      "description": "Map entries of already-migrated content types",
+      "group_name": "Layout"
+    },
+    {
+      "flow_id": "testMigration",
+      "name": 5,
       "title": "Test Migration",
       "description": "Preview the migration process",
       "group_name": "Layout"
@@ -233,7 +246,7 @@
     {
       "flow_id": "migrationExecution",
       "_metadata": { "uid": "csb100b7a598d9c333" },
-      "name": 5,
+      "name": 6,
       "title": "Migration Execution",
       "description": "Wait for the execution for migration complete.",
       "group_name": "SeeDetails"

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -178,14 +178,33 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
     }
   };
 
+  // Clear the right-panel entry table + selection state. Called when the left list becomes empty
+  // (zero search/filter results) so a stale content type's entry table doesn't linger.
+  const resetEntryTable = () => {
+    setTableData([]);
+    setRowIds({});
+    setPersistedRowIds({});
+    setInitialRowSelectedData([]);
+    setTotalCounts(0);
+    setOtherCmsTitle('');
+    setContentTypeUid('');
+    setOtherCmsUid('');
+    setActive(null);
+  };
+
   // Search content types in the left list
   const handleSearch = async (searchCT: string) => {
     setSearchContentType(searchCT);
     try {
       const { data } = await getContentTypes(projectId, 0, 1000, searchCT || '', 'old');
-      setContentTypes(data?.contentTypes ?? []);
-      setFilteredContentTypes(data?.contentTypes ?? []);
-      setCount(data?.contentTypes?.length ?? 0);
+      const nextContentTypes = data?.contentTypes ?? [];
+      setContentTypes(nextContentTypes);
+      setFilteredContentTypes(nextContentTypes);
+      setCount(nextContentTypes?.length ?? 0);
+      // No matching content types → clear the right panel so the previous CT's table doesn't stick around.
+      if (!nextContentTypes?.length) {
+        resetEntryTable();
+      }
     } catch (error) {
       console.error(error);
       return error;
@@ -247,6 +266,12 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
     if (value !== 'All') {
       setFilteredContentTypes(filteredCT);
       setCount(filteredCT?.length);
+      // Filter yielded no content types → clear the right panel so a stale entry table doesn't linger.
+      if (!filteredCT?.length) {
+        resetEntryTable();
+        setShowFilter(false);
+        return;
+      }
       const selectedIndex = filteredCT.findIndex((ct) => ct?.otherCmsUid === otherCmsUid);
       setActive(selectedIndex >= 0 ? selectedIndex : null);
     } else {
@@ -460,7 +485,7 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
   const tableHeight = calcHeight();
 
   const modalProps = {
-    body: 'There is something error occured while generating content mapper. Please go to Legacy Cms step and validate the file again.',
+    body: 'An error occurred while generating the content mapper. Please go to the Legacy CMS step and validate the file again.',
   };
 
   return (

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -1,86 +1,120 @@
 // Libraries
-import { useEffect, useState} from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   Button,
+  Search,
+  Icon,
+  Tooltip,
   InfiniteScrollTable,
   Notification,
-
+  cbModal,
+  CircularLoader,
+  EmptyState,
 } from '@contentstack/venus-components';
 
 // Services
 import { getCMSDataFromFile } from '../../cmsData/cmsSelector';
 import {
   getContentTypes,
+  getFieldMapping,
   getEntryMapping,
   updateEntryMapper,
 } from '../../services/api/migration.service';
 
 // Redux
 import { RootState } from '../../store';
-import { updateMigrationData } from '../../store/slice/migrationDataSlice';
+import { updateMigrationData, updateNewMigrationData } from '../../store/slice/migrationDataSlice';
 
 // Utilities
-import { CS_ENTRIES } from '../../utilities/constants';
-import useBlockNavigation from '../../hooks/userNavigation';
+import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping } from '../../utilities/constants';
+import { validateArray } from '../../utilities/functions';
 
 // Interface
-import { DEFAULT_CONTENT_MAPPING_DATA } from '../../context/app/app.interface';
+import { DEFAULT_CONTENT_MAPPING_DATA, INewMigration } from '../../context/app/app.interface';
 import {
   ContentType,
   TableTypes,
-  UidMap, 
-  EntryMapperType
+  UidMap,
+  EntryMapperType,
+  MouseOrKeyboardEvent,
 } from './contentMapper.interface';
 import { ItemStatusMapProp } from '@contentstack/venus-components/build/components/Table/types';
+import { ModalObj } from '../Modal/modal.interface';
 
+// Components
+import SchemaModal from '../SchemaModal';
 
 // Styles and Assets
 import './index.scss';
+import { NoDataFound, SCHEMA_PREVIEW } from '../../common/assets';
 
-const EntryMapper = ({selectedContentTypeId, tableHeight, onEntrySelectionChange}: {selectedContentTypeId: ContentType | null, tableHeight: number, onEntrySelectionChange?: (contentTypeId: string, hasSelection: boolean) => void}) => {
-  // Redux State
-  const dispatch = useDispatch();
+interface entryMapperProps {
+  handleStepChange: (currentStep: number) => void;
+}
 
-  const { projectId = '' } = useParams<{ projectId: string }>();
-
+/**
+ * Step 4 — Map Entry (delta migration).
+ * Standalone step: left content-type list (only ALREADY-MIGRATED content types, fetched with
+ * filter='old') + right entry-mapping table. Maps source entries to destination Contentstack
+ * entries for content types that were migrated in a previous iteration.
+ */
+const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
+  /** ALL CONTEXT HERE */
+  const migrationData = useSelector((state: RootState) => state?.migration?.migrationData);
   const newMigrationData = useSelector((state: RootState) => state?.migration?.newMigrationData);
   const selectedOrganisation = useSelector((state: RootState) => state?.authentication?.selectedOrganisation);
 
-  // Component State
+  const {
+    contentMappingData: {
+      content_types_heading: contentTypesHeading,
+      search_placeholder: searchPlaceholder,
+    } = {}
+  } = migrationData;
+
+  const dispatch = useDispatch();
+
+  /** ALL STATE HERE */
   const [tableData, setTableData] = useState<EntryMapperType[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
-  const [totalCounts, setTotalCounts] = useState<number>(tableData?.length);
-  const [searchText, setSearchText] = useState<string>('');
-  const [selectedContentType, setSelectedContentType] = useState<ContentType | null>(selectedContentTypeId);
-  const [contentTypes, setContentTypes] = useState<ContentType  []>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(newMigrationData?.isprojectMapped);
+  const [totalCounts, setTotalCounts] = useState<number>(0);
   const [itemStatusMap, setItemStatusMap] = useState({});
 
+  const [searchText, setSearchText] = useState<string>('');
+  const [searchContentType, setSearchContentType] = useState('');
+  const [contentTypes, setContentTypes] = useState<ContentType[]>([]);
+  const [filteredContentTypes, setFilteredContentTypes] = useState<ContentType[]>([]);
+  const [count, setCount] = useState<number>(0);
   const [otherCmsTitle, setOtherCmsTitle] = useState('');
-  const [contentTypeUid, setContentTypeUid] = useState<string>(selectedContentTypeId?.id || '');
+  const [otherCmsUid, setOtherCmsUid] = useState<string>('');
+  const [contentTypeUid, setContentTypeUid] = useState<string>('');
 
-  const [isContentType, setIsContentType] = useState<boolean>(true);
- 
-  const [otherCmsUid, setOtherCmsUid] = useState<string>(contentTypes?.[0]?.otherCmsUid);
+  const [active, setActive] = useState<number | null>(0);
+  const [showFilter, setShowFilter] = useState<boolean>(false);
+  const [activeFilter, setActiveFilter] = useState<string>('');
+
   const [rowIds, setRowIds] = useState<Record<string, boolean>>({});
   const [persistedRowIds, setPersistedRowIds] = useState<Record<string, boolean>>({});
   const [isLoadingSaveButton, setisLoadingSaveButton] = useState<boolean>(false);
   const [initialRowSelectedData, setInitialRowSelectedData] = useState<EntryMapperType[]>([]);
 
+  /** ALL HOOKS HERE */
+  const { projectId = '' } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
+  const filterRef = useRef<HTMLDivElement | null>(null);
+  const tableWrapperRef = useRef<HTMLDivElement | null>(null);
 
-
-    /********** ALL USEEFFECT HERE *************/
+  /********** ALL USEEFFECT HERE *************/
   useEffect(() => {
-    //check if offline CMS data field is set to true, if then read data from cms data file.
+    // check if offline CMS data field is set to true, if then read data from cms data file.
     getCMSDataFromFile(CS_ENTRIES.CONTENT_MAPPING)
       .then((data) => {
-        //Check for null
         if (!data) {
           dispatch(updateMigrationData({ contentMappingData: DEFAULT_CONTENT_MAPPING_DATA }));
           return;
         }
-
         dispatch(updateMigrationData({ contentMappingData: data }));
       })
       .catch((err) => {
@@ -90,14 +124,13 @@ const EntryMapper = ({selectedContentTypeId, tableHeight, onEntrySelectionChange
     fetchContentTypes(searchText || '');
   }, []);
 
+  // Close filter panel when clicking outside
   useEffect(() => {
-    if (selectedContentTypeId) {
-        fetchEntries(selectedContentTypeId?.id || '', searchText);
-        setOtherCmsTitle(selectedContentTypeId?.otherCmsTitle);
-    }
-      
-    },[selectedContentTypeId]);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
+  /********** HELPERS *************/
   const buildSelectedRowIds = (entries: EntryMapperType[]) => {
     return (entries ?? []).reduce<UidMap>((acc, item) => {
       if (item?._canSelect && item?.isUpdate) {
@@ -120,45 +153,132 @@ const EntryMapper = ({selectedContentTypeId, tableHeight, onEntrySelectionChange
     });
   };
 
-  const fetchContentTypes = async (searchText: string) => {
-    //setIsLoading(true);
-
+  /********** CONTENT TYPE LIST (left panel) *************/
+  // Fetch ALREADY-MIGRATED content types only (filter='old') — these are the ones whose entries
+  // exist and can be mapped in this delta iteration.
+  const fetchContentTypes = async (searchVal: string) => {
+    setIsLoading(true);
     try {
-      const { data } = await getContentTypes(projectId || '', 0, 5000, ''); //org id will always present
+      const { data } = await getContentTypes(projectId || '', 0, 5000, searchContentType || '', 'old');
 
+      setIsLoading(false);
+      setContentTypes(data?.contentTypes ?? []);
+      setFilteredContentTypes(data?.contentTypes ?? []);
+      setCount(data?.contentTypes?.length ?? 0);
+      setOtherCmsTitle(data?.contentTypes?.[0]?.otherCmsTitle ?? '');
+      setContentTypeUid(data?.contentTypes?.[0]?.id ?? '');
+      setOtherCmsUid(data?.contentTypes?.[0]?.otherCmsUid ?? '');
+      if (data?.contentTypes?.[0]?.id) {
+        fetchEntries(data?.contentTypes?.[0]?.id, searchVal ?? '');
+      }
+    } catch (error) {
+      setIsLoading(false);
+      console.error(error);
+      return error;
+    }
+  };
 
-      setContentTypes(data?.contentTypes);
-      setSelectedContentType(data?.contentTypes?.[0]);
-      setOtherCmsTitle(data?.contentTypes?.[0]?.otherCmsTitle);
-      setContentTypeUid(data?.contentTypes?.[0]?.id);
-      fetchEntries(data?.contentTypes?.[0]?.id, searchText ?? '');
-      setOtherCmsUid(data?.contentTypes?.[0]?.otherCmsUid);
-      setIsContentType(data?.contentTypes?.[0]?.type === "content_type");
+  // Search content types in the left list
+  const handleSearch = async (searchCT: string) => {
+    setSearchContentType(searchCT);
+    try {
+      const { data } = await getContentTypes(projectId, 0, 1000, searchCT || '', 'old');
+      setContentTypes(data?.contentTypes ?? []);
+      setFilteredContentTypes(data?.contentTypes ?? []);
+      setCount(data?.contentTypes?.length ?? 0);
     } catch (error) {
       console.error(error);
       return error;
     }
   };
 
-   // Method to get fieldmapping
-  const fetchEntries = async (contentTypeId: string, searchText: string) => {
+  const handleOpenContentType = (i = 0) => {
+    // Reset scroll position to top when switching content types
+    if (tableWrapperRef?.current) {
+      const elements = tableWrapperRef.current?.querySelectorAll('.Table__body');
+      elements?.forEach((el) => {
+        if (el instanceof HTMLElement) {
+          el.scrollTop = 0;
+        }
+      });
+    }
+
+    setActive(i);
+    const ct = filteredContentTypes?.[i];
+    setOtherCmsTitle(ct?.otherCmsTitle ?? '');
+    setContentTypeUid(ct?.id ?? '');
+    setOtherCmsUid(ct?.otherCmsUid ?? '');
+    if (ct?.id) {
+      fetchEntries(ct.id, searchText || '');
+    }
+  };
+
+  const handleSchemaPreview = async (title: string, ctId: string) => {
     try {
-      const itemStatusMap: ItemStatusMapProp = {};
+      const { data } = await getFieldMapping(ctId ?? '', 0, 1000, searchText ?? '', projectId);
+      return cbModal({
+        component: (props: ModalObj) => (
+          <SchemaModal schemaData={data?.fieldMapping} contentType={title} {...props} />
+        ),
+        modalProps: {
+          shouldCloseOnOverlayClick: true
+        }
+      });
+    } catch (err) {
+      console.error(err);
+      return err;
+    }
+  };
 
+  // Toggle filter panel
+  const handleFilter = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    setShowFilter(!showFilter);
+  };
+
+  // Filter content types by status
+  const handleContentTypeFilter = (value: string, e: MouseOrKeyboardEvent) => {
+    setActiveFilter(value);
+    const li_list = document.querySelectorAll('.filter-wrapper li');
+    li_list?.forEach((ele) => ele?.classList?.remove('active-filter'));
+    (e?.target as HTMLElement)?.closest('li')?.classList?.add('active-filter');
+
+    const filteredCT = contentTypes?.filter((ct) => CONTENT_MAPPING_STATUS[ct?.status] === value);
+    if (value !== 'All') {
+      setFilteredContentTypes(filteredCT);
+      setCount(filteredCT?.length);
+      const selectedIndex = filteredCT.findIndex((ct) => ct?.otherCmsUid === otherCmsUid);
+      setActive(selectedIndex >= 0 ? selectedIndex : null);
+    } else {
+      setFilteredContentTypes(contentTypes);
+      setCount(contentTypes?.length);
+      setActive(contentTypes?.findIndex((ct) => ct?.otherCmsUid === otherCmsUid));
+    }
+    setShowFilter(false);
+  };
+
+  const handleClickOutside = (evt: MouseEvent) => {
+    if (!filterRef.current?.contains(evt.target as Node)) {
+      setShowFilter(false);
+    }
+  };
+
+  /********** ENTRY TABLE (right panel) *************/
+  const fetchEntries = async (ctId: string, searchVal: string) => {
+    try {
+      const itemStatusMapLocal: ItemStatusMapProp = {};
       for (let index = 0; index <= 1000; index++) {
-        itemStatusMap[index] = 'loading';
+        itemStatusMapLocal[index] = 'loading';
       }
-
-      setItemStatusMap(itemStatusMap);
+      setItemStatusMap(itemStatusMapLocal);
       setLoading(true);
-     
-      const { data } = await getEntryMapping(contentTypeId || '', 0, 1000, searchText, projectId);
-      
-      for (let index = 0; index <= 1000; index++) {
-        itemStatusMap[index] = 'loaded';
-      }
 
-      setItemStatusMap({ ...itemStatusMap });
+      const { data } = await getEntryMapping(ctId || '', 0, 1000, searchVal, projectId);
+
+      for (let index = 0; index <= 1000; index++) {
+        itemStatusMapLocal[index] = 'loaded';
+      }
+      setItemStatusMap({ ...itemStatusMapLocal });
       setLoading(false);
 
       const validTableData: EntryMapperType[] = (data?.entryMapping ?? []).map((entry: EntryMapperType) => ({
@@ -166,52 +286,42 @@ const EntryMapper = ({selectedContentTypeId, tableHeight, onEntrySelectionChange
         _canSelect: !!entry?.contentstackEntryUid,
       }));
 
-      //setIsAllCheck(true);
       const initialSelected = buildSelectedRowIds(validTableData ?? []);
       setTableData(validTableData ?? []);
       setRowIds(initialSelected);
       setPersistedRowIds(initialSelected);
       setTotalCounts(validTableData?.length);
-      setInitialRowSelectedData(validTableData?.filter((item: EntryMapperType) => !item?.isUpdate))
-
-      // Reflect any pre-existing entry selections on the content type icon (green when present)
-      const ctId = contentTypeId || selectedContentTypeId?.id;
-      if (ctId) {
-        onEntrySelectionChange?.(ctId, Object.keys(initialSelected ?? {}).length > 0);
-      }
-     
+      setInitialRowSelectedData(validTableData?.filter((item: EntryMapperType) => !item?.isUpdate));
+      // Reflect any pre-existing entry selections on the content type icon (green when present).
+      updateContentTypeStatus(ctId, Object.keys(initialSelected ?? {}).length > 0);
     } catch (error) {
-      console.error('fetchData -> error', error);
+      console.error('fetchEntries -> error', error);
     }
   };
 
-    // Fetch table data
-  const fetchData = async ({ searchText }: TableTypes) => {
-    setSearchText(searchText)
-    selectedContentTypeId?.id && fetchEntries(selectedContentTypeId?.id, searchText);
+  // Fetch table data on search
+  const fetchData = async ({ searchText: search }: TableTypes) => {
+    setSearchText(search);
+    contentTypeUid && fetchEntries(contentTypeUid, search);
   };
 
-  // Method for Load more table data
-  const loadMoreItems = async ({ searchText, skip, limit, startIndex, stopIndex }: TableTypes) => {
+  // Load more table data
+  const loadMoreItems = async ({ searchText: search, skip, limit, startIndex, stopIndex }: TableTypes) => {
     try {
       const itemStatusMapCopy: ItemStatusMapProp = { ...itemStatusMap };
-
       for (let index = startIndex; index <= stopIndex; index++) {
         itemStatusMapCopy[index] = 'loading';
       }
-
       setItemStatusMap({ ...itemStatusMapCopy });
       setLoading(true);
 
-      const { data } = await getEntryMapping(contentTypeUid || '', skip, limit, searchText || '', projectId);
+      const { data } = await getEntryMapping(contentTypeUid || '', skip, limit, search || '', projectId);
 
-      const updateditemStatusMapCopy: ItemStatusMapProp = { ...itemStatusMap };
-
+      const updated: ItemStatusMapProp = { ...itemStatusMap };
       for (let index = startIndex; index <= stopIndex; index++) {
-        updateditemStatusMapCopy[index] = 'loaded';
+        updated[index] = 'loaded';
       }
-
-      setItemStatusMap({ ...updateditemStatusMapCopy });
+      setItemStatusMap({ ...updated });
       setLoading(false);
 
       const validTableData: EntryMapperType[] = (data?.entryMapping ?? []).map((entry: EntryMapperType) => ({
@@ -219,151 +329,114 @@ const EntryMapper = ({selectedContentTypeId, tableHeight, onEntrySelectionChange
         _canSelect: !!entry?.contentstackEntryUid,
       }));
 
-      // eslint-disable-next-line no-unsafe-optional-chaining
       setTableData(applySelectionToEntries(validTableData ?? [], rowIds));
-
     } catch (error) {
       console.error('loadMoreItems -> error', error);
     }
   };
 
-   /**
-     * Handle the selected entries
-     * @param singleSelectedRowIds - The single selected row IDs
-     * @returns void
-     */
-    const handleSelectedEntries = (singleSelectedRowIds: string[]) => {
-      const selectedObj: UidMap = {};
-      singleSelectedRowIds?.forEach((uid: string) => {
-        selectedObj[uid] = true;
-      });
+  /**
+   * Reflect entry-update selection on the content type's status icon:
+   * has selected entries → 'Updated' (status '2', green); none → 'Mapped' (status '1', blue).
+   */
+  const updateContentTypeStatus = (contentTypeId: string, hasSelection: boolean) => {
+    if (!contentTypeId) return;
+    const nextStatus = hasSelection ? '2' : '1';
+    const applyStatus = (list: ContentType[]) =>
+      list?.map?.((ct) => (ct?.id === contentTypeId ? { ...ct, status: nextStatus } : ct));
+    setContentTypes((prev) => applyStatus(prev));
+    setFilteredContentTypes((prev) => applyStatus(prev));
+  };
 
-      setRowIds(selectedObj);
-      setTableData((prev) => applySelectionToEntries(prev ?? [], selectedObj));
-    };
-    
-    const handleSaveContentType = async () => {
-      console.info("handleSaveContentType", rowIds);
-      setisLoadingSaveButton(true);
-      const allKeys = new Set([
-        ...Object.keys(rowIds ?? {}),
-        ...Object.keys(persistedRowIds ?? {}),
-      ]);
-      const changedUids = Array.from(allKeys).filter(
-        (uid) => !!rowIds?.[uid] !== !!persistedRowIds?.[uid],
-      );
-          const orgId = selectedOrganisation?.uid;
-          // const projectID = projectId;
-      
-      if (orgId && contentTypeUid) {
-        const dataCs = {
-          ids: changedUids
-        };
+  // Handle selected entries
+  const handleSelectedEntries = (singleSelectedRowIds: string[]) => {
+    const selectedObj: UidMap = {};
+    singleSelectedRowIds?.forEach((uid: string) => {
+      selectedObj[uid] = true;
+    });
+    setRowIds(selectedObj);
+    setTableData((prev) => applySelectionToEntries(prev ?? [], selectedObj));
+  };
+
+  const handleSaveContentType = async () => {
+    setisLoadingSaveButton(true);
+    const allKeys = new Set([
+      ...Object.keys(rowIds ?? {}),
+      ...Object.keys(persistedRowIds ?? {}),
+    ]);
+    const changedUids = Array.from(allKeys).filter(
+      (uid) => !!rowIds?.[uid] !== !!persistedRowIds?.[uid],
+    );
+    const orgId = selectedOrganisation?.uid;
+
+    if (orgId && contentTypeUid) {
+      const dataCs = { ids: changedUids };
       try {
         if (changedUids.length === 0) {
           setisLoadingSaveButton(false);
           return Notification({
             notificationContent: { text: 'No changes to save' },
-            notificationProps: {
-              position: 'bottom-center',
-              hideProgressBar: true
-            },
+            notificationProps: { position: 'bottom-center', hideProgressBar: true },
             type: 'info'
           });
         }
-        const {data, status} = await updateEntryMapper(projectId, dataCs);
-        console.info("status", status, typeof status, data);
-      
-        setisLoadingSaveButton(false);  
+        const { status } = await updateEntryMapper(projectId, dataCs);
+        setisLoadingSaveButton(false);
         if (status === 200) {
           setPersistedRowIds({ ...(rowIds ?? {}) });
           setLoading(false);
-
-          // Reflect the saved update on the content type icon: green (Updated) when entries
-          // remain selected after save, blue (Mapped) when all selections were cleared.
-          const ctId = selectedContentTypeId?.id || contentTypeUid;
-          if (ctId) {
-            const hasSelection = Object.values(rowIds ?? {}).some(Boolean);
-            onEntrySelectionChange?.(ctId, hasSelection);
-          }
-
+          // Reflect the saved state on the content type icon: green (Updated) when entries remain
+          // selected after save, blue (Mapped) when all selections were cleared.
+          updateContentTypeStatus(contentTypeUid, Object.values(rowIds ?? {}).some(Boolean));
           return Notification({
             notificationContent: { text: 'Entries saved successfully' },
-            notificationProps: {
-              position: 'bottom-center',
-              hideProgressBar: true
-            },
+            notificationProps: { position: 'bottom-center', hideProgressBar: true },
             type: 'success'
           });
         }
-        else{
-          setisLoadingSaveButton(false);
-          return Notification({
-            notificationContent: { text: 'Failed to save entries' },
-            notificationProps: {
-              position: 'bottom-center',
-              hideProgressBar: true
-            },
-            type: 'error'
-          });
-        }
+        return Notification({
+          notificationContent: { text: 'Failed to save entries' },
+          notificationProps: { position: 'bottom-center', hideProgressBar: true },
+          type: 'error'
+        });
       } catch (error) {
         console.error(error);
         setisLoadingSaveButton(false);
         return error;
       }
-      
-      }
     }
-   const accessorCall = (data: EntryMapperType) => {
-    // Clean field name (remove parent hierarchy)
-    const cleanFieldName = data?.entryName
-    return (
-        <div>
-          <div className='d-flex align-items-center '>           
-            <div className={'cms-field'}>
-              {cleanFieldName}
-            </div>           
-          </div>
-        </div>
-    );
   };
 
-    const accessorContentstackCall = (data: EntryMapperType) => {
-    // Clean field name (remove parent hierarchy)
-    const cleanFieldName = data?.contentstackEntryUid
-    return ( 
-        <div>
-          <div className='d-flex align-items-center'>           
-            <div className={'cms-field'}>
-              {cleanFieldName ? cleanFieldName : '-'}
-            </div>           
-          </div>
-        </div>
-    
-    );
-  };
-
-  const accessorForCMSUid = (data: EntryMapperType) => { 
-    const cleanFieldName = data?.otherCmsEntryUid
-    return (
-      <div>
-        <div className='d-flex align-items-center'>           
-          <div className={'cms-field'}>
-            {cleanFieldName ? cleanFieldName : '-'}
-          </div>           
-        </div>
+  /********** TABLE COLUMNS *************/
+  const accessorCall = (data: EntryMapperType) => (
+    <div>
+      <div className="d-flex align-items-center">
+        <div className={'cms-field'}>{data?.entryName}</div>
       </div>
-    );
-  }
+    </div>
+  );
 
-   const columns = [
+  const accessorForCMSUid = (data: EntryMapperType) => (
+    <div>
+      <div className="d-flex align-items-center">
+        <div className={'cms-field'}>{data?.otherCmsEntryUid ? data?.otherCmsEntryUid : '-'}</div>
+      </div>
+    </div>
+  );
+
+  const accessorContentstackCall = (data: EntryMapperType) => (
+    <div>
+      <div className="d-flex align-items-center">
+        <div className={'cms-field'}>{data?.contentstackEntryUid ? data?.contentstackEntryUid : '-'}</div>
+      </div>
+    </div>
+  );
+
+  const columns = [
     {
       disableSortBy: true,
       Header: (
-        <span >
-          {`${newMigrationData?.legacy_cms?.selectedCms?.title}: ${otherCmsTitle}`}
-        </span>
+        <span>{`${newMigrationData?.legacy_cms?.selectedCms?.title}: ${otherCmsTitle}`}</span>
       ),
       accessor: accessorCall,
       id: 'uuid',
@@ -371,72 +444,227 @@ const EntryMapper = ({selectedContentTypeId, tableHeight, onEntrySelectionChange
     },
     {
       disableSortBy: true,
-      Header: (
-        <span >
-          {`${newMigrationData?.legacy_cms?.selectedCms?.title} UIDs:`}
-        </span>
-      ),
+      Header: <span>{`${newMigrationData?.legacy_cms?.selectedCms?.title} UIDs:`}</span>,
       accessor: accessorForCMSUid,
       id: '1'
     },
     {
       disableSortBy: true,
-      Header: (
-        <span >
-          {'Contentstack UIDs:'}
-        </span>
-      ),
-     accessor: accessorContentstackCall,
+      Header: <span>{'Contentstack UIDs:'}</span>,
+      accessor: accessorContentstackCall,
       id: '2'
     }
   ];
 
+  const calcHeight = () => window.innerHeight - 361;
+  const tableHeight = calcHeight();
+
+  const modalProps = {
+    body: 'There is something error occured while generating content mapper. Please go to Legacy Cms step and validate the file again.',
+  };
+
   return (
-    <div className='entry-mapper-container'>
-      <InfiniteScrollTable
-        key={contentTypeUid || selectedContentTypeId?.id || 'entry-mapper-table'}
-        loading={loading}
-        canSearch={true}
-        totalCounts={Math.max(0, tableData?.length)}
-        data={[...tableData]}
-        columns={columns}
-        uniqueKey={'id'}
-        isRowSelect={true}
-        fullRowSelect={true}
-        itemStatusMap={itemStatusMap}
-        fetchTableData={fetchData}
-        loadMoreItems={loadMoreItems}
-        tableHeight={tableHeight}
-        equalWidthColumns={true}
-        columnSelector={false}
-        initialSelectedRowIds={rowIds}
-        itemSize={80}
-        getSelectedRow={handleSelectedEntries}
-        rowSelectCheckboxProp={{ key: '_canSelect', value: true }}
-        name={{
-            singular: '',
-            plural: `${totalCounts === 0 ? 'Count' : ''}`
-        }}
-
-    />
-    {totalCounts > 0 && (
-      <div className="mapper-footer">
-          <div>Total Entries: <strong>{totalCounts}</strong></div>
-          <Button
-            className="saveButton"
-            onClick={handleSaveContentType}
-            version="v2"
-            disabled={newMigrationData?.project_current_step > 4}
-            //isLoading={isLoadingSaveButton}
-          >
-            Save
-          </Button>
+    isLoading || newMigrationData?.isprojectMapped
+      ? <div className="loader-container">
+        <CircularLoader />
       </div>
-    )}
+      :
+      <div className="step-container">
+        {(contentTypes?.length > 0 || tableData?.length > 0) ?
+          <div className="d-flex flex-wrap table-container">
+            {/* Content Types List */}
+            <div className="content-types-list-wrapper">
+              <div className="content-types-list-header d-flex align-items-center justify-content-between">
+                {contentTypesHeading && <h2>{`${contentTypesHeading} (${contentTypes && count})`}</h2>}
+              </div>
 
-      
-    </div>
-    
-  )
-}
+              <div className='ct-search-wrapper'>
+                <div className='d-flex align-items-center'>
+                  <Search
+                    placeholder={searchPlaceholder}
+                    type="secondary"
+                    version="v2"
+                    onChange={(search: string) => handleSearch(search)}
+                    onClear={true}
+                    value={searchContentType}
+                    debounceSearch={true}
+                  />
+
+                  <Button buttonType="light" onClick={handleFilter} className="ml-8">
+                    <Icon icon="Filter" version="v2" />
+                  </Button>
+                  {showFilter && (
+                    <div className='filter-wrapper' ref={filterRef}>
+                      <ul>
+                        {Object.keys(CONTENT_MAPPING_STATUS)?.map?.((key, keyInd) => (
+                          <li key={`${keyInd?.toString()}`}>
+                            <button
+                              className='list-button'
+                              onClick={(e) => handleContentTypeFilter(CONTENT_MAPPING_STATUS[key], e)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                  handleContentTypeFilter(CONTENT_MAPPING_STATUS[key], e);
+                                }
+                              }}
+                            >
+                              {CONTENT_MAPPING_STATUS[key] && <span className={`${activeFilter === CONTENT_MAPPING_STATUS[key] ? 'filter-status filterButton-color' : 'filter-status'}`}>{CONTENT_MAPPING_STATUS[key]}</span>}
+                              {STATUS_ICON_Mapping[key] && <Icon size="small" icon={STATUS_ICON_Mapping[key]} className={STATUS_ICON_Mapping[key] === 'CheckedCircle' ? 'mapped-icon' : ''} />}
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {filteredContentTypes && validateArray(filteredContentTypes)
+                ? <div className='ct-list-wrapper'>
+                  <ul className="ct-list">
+                    {filteredContentTypes?.map?.((content: ContentType, index: number) => {
+                      const icon = STATUS_ICON_Mapping[content?.status] || '';
+                      const format = (str: string) => {
+                        const frags = str?.split('_');
+                        for (let i = 0; i < frags?.length; i++) {
+                          frags[i] = frags?.[i]?.charAt?.(0)?.toUpperCase() + frags?.[i]?.slice(1);
+                        }
+                        return frags?.join?.(' ');
+                      };
+                      return (
+                        <li key={`${index?.toString()}`} className={`${active == index ? 'active-ct' : ''}`}>
+                          <button
+                            type='button'
+                            className='list-button ct-names'
+                            onClick={(e) => {
+                              if (otherCmsUid === filteredContentTypes[index]?.otherCmsUid) {
+                                e.preventDefault();
+                              } else {
+                                handleOpenContentType(index);
+                              }
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' && otherCmsUid !== filteredContentTypes[index]?.otherCmsUid) {
+                                handleOpenContentType(index);
+                              }
+                            }}
+                          >
+                            <div className='cms-title'>
+                              <Tooltip content={format(content?.type)} position="bottom">
+                                {content?.type === "content_type"
+                                  ? <Icon icon={active == index ? "ContentModelsMediumActive" : "ContentModelsMedium"} size="small" />
+                                  : <Icon icon={active == index ? "GlobalFieldsMediumActive" : "GlobalFieldsMedium"} size="small" />
+                                }
+                              </Tooltip>
+                              {content?.otherCmsTitle && <span title={content?.otherCmsTitle}>{content?.otherCmsTitle}</span>}
+                            </div>
+                          </button>
+                          <div className='d-flex align-items-center ct-options'>
+                            <span>
+                              {icon && (
+                                <Tooltip content={CONTENT_MAPPING_STATUS[content?.status]} position="bottom">
+                                  <Icon size="small" icon={icon} className={icon === 'CheckedCircle' ? 'mapped-icon' : ''} />
+                                </Tooltip>
+                              )}
+                            </span>
+                            <span className='ml-10'>
+                              <Tooltip content="Schema Preview" position="bottom">
+                                <button className='list-button schema-preview' aria-label="schemaPreview" onClick={() => handleSchemaPreview(content?.otherCmsTitle, content?.id ?? '')}>{SCHEMA_PREVIEW}</button>
+                              </Tooltip>
+                            </span>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+                : <div className='no-content'>No Content Types Found.</div>
+              }
+            </div>
+
+            {/* Entry Mapping Table */}
+            <div className="content-types-fields-wrapper">
+              <div className="table-wrapper" ref={tableWrapperRef}>
+                <div className='entry-mapper-container'>
+                  <InfiniteScrollTable
+                    key={contentTypeUid || 'entry-mapper-table'}
+                    loading={loading}
+                    canSearch={true}
+                    totalCounts={Math.max(0, tableData?.length)}
+                    data={[...tableData]}
+                    columns={columns}
+                    uniqueKey={'id'}
+                    isRowSelect={true}
+                    fullRowSelect={true}
+                    itemStatusMap={itemStatusMap}
+                    fetchTableData={fetchData}
+                    loadMoreItems={loadMoreItems}
+                    tableHeight={tableHeight}
+                    equalWidthColumns={true}
+                    columnSelector={false}
+                    initialRowSelectedData={initialRowSelectedData}
+                    initialSelectedRowIds={rowIds}
+                    itemSize={80}
+                    getSelectedRow={handleSelectedEntries}
+                    rowSelectCheckboxProp={{ key: '_canSelect', value: true }}
+                    name={{
+                      singular: '',
+                      plural: `${totalCounts === 0 ? 'Count' : ''}`
+                    }}
+                  />
+                  {totalCounts > 0 && (
+                    <div className="mapper-footer">
+                      <div>Total Entries: <strong>{totalCounts}</strong></div>
+                      <Button
+                        className="saveButton"
+                        onClick={handleSaveContentType}
+                        version="v2"
+                        disabled={newMigrationData?.project_current_step > 4}
+                        isLoading={isLoadingSaveButton}
+                      >
+                        Save
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div> :
+          <EmptyState
+            forPage="emptyStateV2"
+            heading={<div className="empty_search_heading">No Content Types available</div>}
+            description={
+              <div className="empty_search_description">
+                {modalProps?.body}
+              </div>
+            }
+            className="mapper-emptystate"
+            img={NoDataFound}
+            actions={
+              <Button buttonType="secondary" size="small" version="v2"
+                onClick={() => {
+                  const newMigrationDataObj: INewMigration = {
+                    ...newMigrationData,
+                    legacy_cms: {
+                      ...newMigrationData?.legacy_cms,
+                      uploadedFile: {
+                        ...newMigrationData?.legacy_cms?.uploadedFile,
+                        reValidate: true,
+                        buttonClicked: true,
+                      }
+                    }
+                  };
+                  dispatch(updateNewMigrationData(newMigrationDataObj));
+                  handleStepChange(0);
+                  const url = `/projects/${projectId}/migration/steps/1`;
+                  navigate(url, { replace: true });
+                }}
+                className='ml-10'>Go to Legacy CMS</Button>
+            }
+            version="v2"
+            testId="no-results-found-page"
+          />}
+      </div>
+  );
+};
+
 export default EntryMapper;

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -152,8 +152,8 @@
     border-left: 0 none;
     min-height: 24.25rem;
     .Table__body__row {
-        .Table-select-body {
-         >.checkbox-wrapper {
+      .Table-select-body {
+        > .checkbox-wrapper {
           align-items: flex-start;
         }
       }
@@ -313,6 +313,15 @@ div .table-row {
 .mapper-emptystate {
   padding: 10px 10px;
 }
+// Delta iteration empty state has no "Go to Legacy CMS" action button, so center it vertically
+// in the available space instead of sitting top-heavy.
+.mapper-emptystate--centered {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+}
 .Checkbox .Checkbox__tick svg {
   display: block;
 }
@@ -323,11 +332,11 @@ div .table-row {
   font-size: $size-font-large;
   font-weight: $font-weight-semi-bold;
 }
-.filterButton-color{
+.filterButton-color {
   color: $color-brand-primary-base;
   font-weight: $font-weight-bold;
 }
-.icon-padding{
+.icon-padding {
   padding: 10px 10px;
   margin-left: 6px;
 }
@@ -337,23 +346,23 @@ div .table-row {
     font-weight: 600;
     // margin-left: 16px;
   }
-  
+
   &.child-row {
     margin-left: 26px;
   }
-  
+
   &.child-row-level-2 {
     border-left: 1px solid $color-brand-secondary-lightest;
     margin-left: 36px;
     padding-left: 16px;
   }
-  
+
   &.child-row-level-3 {
     border-left: 1px solid $color-brand-secondary-lightest;
     margin-left: 62px;
     padding-left: 16px;
   }
-  
+
   &.child-row-level-4 {
     border-left: 1px solid $color-brand-secondary-lightest;
     margin-left: 98px;
@@ -432,14 +441,14 @@ div .table-row {
 .table-row {
   display: flex;
   align-items: center;
-  gap: 8px;                   
+  gap: 8px;
 }
 .table-row .select {
-  flex: 1;                    
+  flex: 1;
 }
 .advanced-setting-button,
 .table-row button {
-  flex-shrink: 0;           
+  flex-shrink: 0;
 }
 
 // Prevent header wrapping
@@ -478,7 +487,7 @@ div .table-row {
   overflow-y: auto !important;
 }
 
-// Safety for small screens 
+// Safety for small screens
 @media (max-height: 800px) {
   .mapper-footer {
     padding: 10px;
@@ -487,7 +496,7 @@ div .table-row {
 
 .select {
   .tippy-wrapper {
-    display: inline; 
+    display: inline;
   }
 }
 

--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -1016,7 +1016,6 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
     try {
       const { data } = await getContentTypes(projectId || '', 0, 5000, searchContentType || '', 'new'); //org id will always present
 
-      setIsLoading(false);
       setContentTypes(data?.contentTypes);
       setCount(data?.contentTypes?.length);
       setFilteredContentTypes(data?.contentTypes);
@@ -1033,7 +1032,11 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
       dispatch(updateNewMigrationData({ hasNoContentTypes: !(data?.contentTypes?.length > 0) }));
     } catch (error) {
       console.error(error);
+      // On failure treat step 3 as empty so the Continue gate doesn't hang in an undefined state.
+      dispatch(updateNewMigrationData({ hasNoContentTypes: true }));
       return error;
+    } finally {
+      setIsLoading(false);
     }
   };
 

--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -41,7 +41,7 @@ import { RootState } from '../../store';
 import { updateMigrationData, updateNewMigrationData } from '../../store/slice/migrationDataSlice';
 
 // Utilities
-import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping } from '../../utilities/constants';
+import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping, CONTENT_MAPPER_EMPTY_STATE } from '../../utilities/constants';
 import { isEmptyString, validateArray } from '../../utilities/functions';
 import useBlockNavigation from '../../hooks/userNavigation';
 
@@ -85,7 +85,6 @@ import {
 // Styles and Assets
 import './index.scss';
 import { NoDataFound, SCHEMA_PREVIEW } from '../../common/assets';
-import EntryMapper from './entryMapper';
 
 const FIELD_MAP_MENU_VIEW_MARGIN = 8;
 const FIELD_MAP_MENU_HYSTERESIS = 36;
@@ -494,9 +493,6 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
   const migrationData = useSelector((state: RootState) => state?.migration?.migrationData);
   const newMigrationData = useSelector((state: RootState) => state?.migration?.newMigrationData);
   const selectedOrganisation = useSelector((state: RootState) => state?.authentication?.selectedOrganisation);
-  const iteration = useSelector(
-    (state: RootState) => state?.migration?.newMigrationData?.iteration
-  );
   // When setting contentModels from Redux, ensure it's cloned
   const reduxContentTypes = newMigrationData?.content_mapping?.existingCT; // Assume this gets your Redux state
   const reduxGlobalFields = newMigrationData?.content_mapping?.existingGlobal
@@ -1018,7 +1014,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
     setIsLoading(true);
 
     try {
-      const { data } = await getContentTypes(projectId || '', 0, 5000, searchContentType || ''); //org id will always present
+      const { data } = await getContentTypes(projectId || '', 0, 5000, searchContentType || '', 'new'); //org id will always present
 
       setIsLoading(false);
       setContentTypes(data?.contentTypes);
@@ -1031,6 +1027,10 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
       fetchFields(data?.contentTypes?.[0]?.id, searchText || '');
       setOtherCmsUid(data?.contentTypes?.[0]?.otherCmsUid);
       setIsContentType(data?.contentTypes?.[0]?.type === "content_type");
+
+      // Report whether step 3 has any content types so the header can gate the Continue button:
+      // empty on iteration 1 = error (disable), empty on iteration 2+ = no new types (allow continue).
+      dispatch(updateNewMigrationData({ hasNoContentTypes: !(data?.contentTypes?.length > 0) }));
     } catch (error) {
       console.error(error);
       return error;
@@ -1042,7 +1042,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
     setSearchContentType(searchCT);
 
     try {
-      const { data } = await getContentTypes(projectId, 0, 1000, searchCT || ''); //org id will always present
+      const { data } = await getContentTypes(projectId, 0, 1000, searchCT || '', 'new'); //org id will always present
 
       setContentTypes(data?.contentTypes);
       setFilteredContentTypes(data?.contentTypes);
@@ -1126,19 +1126,6 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
     } catch (error) {
       console.error('loadMoreItems -> error', error);
     }
-  };
-
-  // Method to change the content type
-  /**
-   * Reflect entry-update selection on the content type's status icon:
-   * has selected entries → 'Updated' (status '2', green); none → 'Mapped' (status '1', blue).
-   */
-  const handleEntrySelectionStatusChange = (contentTypeId: string, hasSelection: boolean) => {
-    const nextStatus = hasSelection ? '2' : '1';
-    const applyStatus = (list: ContentType[]) =>
-      list?.map?.((ct) => (ct?.id === contentTypeId ? { ...ct, status: nextStatus } : ct));
-    setContentTypes((prev) => applyStatus(prev));
-    setFilteredContentTypes((prev) => applyStatus(prev));
   };
 
   const handleOpenContentType = (i = 0) => {
@@ -1678,7 +1665,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
               !(data?.contentstackFieldType === 'single_line_text' ||
               data?.contentstackFieldType === 'multi_line_text' || data?.contentstackFieldType === 'html' || data?.contentstackFieldType === 'json') ||
               data?.otherCmsType === undefined ||
-              newMigrationData?.project_current_step > 4
+              newMigrationData?.project_current_step > 3
             }
           />
         </div>
@@ -1697,12 +1684,12 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
               disabled={
                 data?.otherCmsField === 'title' ||
                 data?.otherCmsField === 'url' ||
-                newMigrationData?.project_current_step > 4
+                newMigrationData?.project_current_step > 3
               }
             >
               <Button
                 buttonType="light"
-                disabled={newMigrationData?.project_current_step > 4}
+                disabled={newMigrationData?.project_current_step > 3}
                 onClick={() =>
                   handleAdvancedSetting(fieldLabel, data?.advanced || {}, data?.uid, data)
                 }
@@ -1711,7 +1698,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                   version="v2"
                   icon="Sliders"
                   size="small"
-                  disabled={newMigrationData?.project_current_step > 4}
+                  disabled={newMigrationData?.project_current_step > 3}
                 />
 
               </Button>
@@ -2589,7 +2576,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
               maxWidth="290px"
               isClearable={isTypeMatch && selectedOptions?.includes?.(existingField?.[data?.backupFieldUid]?.label ?? '')}
               options={adjustedOptions}
-              isDisabled={OptionValue?.isDisabled || newMigrationData?.project_current_step > 4}
+              isDisabled={OptionValue?.isDisabled || newMigrationData?.project_current_step > 3}
             />
           </Tooltip>
         </div>
@@ -2610,7 +2597,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
               >
                 <Button
                   buttonType="light"
-                  disabled={(resolvedSchema && existingField[data?.backupFieldUid]) || newMigrationData?.project_current_step > 4}
+                  disabled={(resolvedSchema && existingField[data?.backupFieldUid]) || newMigrationData?.project_current_step > 3}
                   onClick={() => {
                     handleAdvancedSetting(initialOption?.label, data?.advanced || {}, data?.uid, data);
                   }}
@@ -3279,8 +3266,15 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
   //variable for button component in table
   const onlyIcon = true;
 
+  // Delta migration: on iteration 2+, an empty content-type list just means there are no NEW
+  // content types to map this round — that's valid, not an error, and the user can continue.
+  // On iteration 1, an empty list means content-mapper generation failed (genuine error).
+  const isDeltaIteration = (newMigrationData?.iteration ?? 1) > 1;
+
   const modalProps = {
-    body: 'There is something error occured while generating content mapper. Please go to Legacy Cms step and validate the file again.',
+    body: isDeltaIteration
+      ? CONTENT_MAPPER_EMPTY_STATE.NO_NEW_CONTENT_TYPES_DESCRIPTION
+      : CONTENT_MAPPER_EMPTY_STATE.NO_CONTENT_TYPES_DESCRIPTION,
     isCancel: false,
     header: "",
   }
@@ -3408,15 +3402,6 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
             {/* Content Type Fields */}
             <div className="content-types-fields-wrapper">
               <div className="table-wrapper" ref={tableWrapperRef}>
-                {iteration > 1 ? (
-                  <div>
-                  <EntryMapper
-                    tableHeight={tableHeight}
-                    selectedContentTypeId={selectedContentType ?? null}
-                    onEntrySelectionChange={handleEntrySelectionStatusChange}
-                  />
-                </div>
-                ): (
                   <div>
                 <InfiniteScrollTable
                   loading={loading}
@@ -3453,7 +3438,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                                 placeholder={otherContentType?.label}
                                 isSearchable
                                 version="v2"
-                                isDisabled={newMigrationData?.project_current_step > 4}
+                                isDisabled={newMigrationData?.project_current_step > 3}
                               />
                             </div>
 
@@ -3489,7 +3474,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                       className="saveButton"
                       onClick={handleSaveContentType}
                       version="v2"
-                      disabled={newMigrationData?.project_current_step > 4}
+                      disabled={newMigrationData?.project_current_step > 3}
                       isLoading={isLoadingSaveButton}
                     >
                       Save
@@ -3497,21 +3482,23 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                   </div>
                 )}
               </div>
-                )}
             </div>
             </div>
           </div> :
           <EmptyState
             forPage="emptyStateV2"
-            heading={<div className="empty_search_heading">No Content Types available</div>}
+            heading={<div className="empty_search_heading">{isDeltaIteration ? CONTENT_MAPPER_EMPTY_STATE.NO_NEW_CONTENT_TYPES_HEADING : CONTENT_MAPPER_EMPTY_STATE.NO_CONTENT_TYPES_HEADING}</div>}
             description={
               <div className="empty_search_description">
                 {modalProps?.body}
               </div>
             }
-            className="mapper-emptystate"
+            className={`mapper-emptystate${isDeltaIteration ? ' mapper-emptystate--centered' : ''}`}
             img={NoDataFound}
-            actions={
+            {...(!isDeltaIteration && {
+              // "Go to Legacy CMS" is only relevant on iteration 1 (empty list = generation error).
+              // On delta iterations an empty list just means no new content types, so omit it entirely.
+              actions: (
                 <Button buttonType="secondary" size="small" version="v2"
                   onClick={() => {
                     const newMigrationDataObj: INewMigration = {
@@ -3531,7 +3518,8 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                     navigate(url, { replace: true });
                   }}
                   className='ml-10'>Go to Legacy CMS</Button>
-            }
+              )
+            })}
             version="v2"
             testId="no-results-found-page"
           />}

--- a/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
@@ -185,7 +185,7 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
               )}
             </div>
             <div className={`edit-icon${isValidated ? ' edit-icon--disabled' : ''}`}>
-              <Icon icon="EditSmallActive" size="small" onClick={handleEditSql} />
+              <Icon icon="EditSmallActive" size="small" onClick={handleEditSql} tooltipContent="Edit SQL Details" tooltipPosition='bottom'/>
             </div>
           </div>
         )
@@ -209,7 +209,7 @@ const FileComponent = ( { fileDetails, fileFormatId }: Props ) =>
           )}
         </div>
         <div className={`edit-icon${isValidated ? ' edit-icon--disabled' : ''}`}>
-          <Icon icon="EditSmallActive" size="small" onClick={handleEditFile} />
+          <Icon icon="EditSmallActive" size="small" onClick={handleEditFile} tooltipContent="Edit Local Path" />
         </div>
       </div>
       ) : (

--- a/ui/src/components/MigrationFlowHeader/index.tsx
+++ b/ui/src/components/MigrationFlowHeader/index.tsx
@@ -47,6 +47,20 @@ const MigrationFlowHeader = ({
   const newMigrationData = useSelector((state: RootState) => state?.migration?.newMigrationData);
   const dispatch = useDispatch();
 
+  // Delta migration: the "Map Entry" step only exists from iteration 2 onwards, which shifts the
+  // step numbers for Test Migration and Execute Migration. Resolve the semantic step ids by
+  // iteration so all stepId checks stay correct for both the 5-step (iter 1) and 6-step flows.
+  const iteration = newMigrationData?.iteration ?? 1;
+  const isDeltaIteration = iteration > 1;
+  const TEST_MIGRATION_STEP = isDeltaIteration ? '5' : '4';
+  const EXECUTE_MIGRATION_STEP = isDeltaIteration ? '6' : '5';
+  // Mapping steps that show a plain "Continue" CTA: Map Content Fields (3) always, plus
+  // Map Entry (4) and Test Migration on delta iterations.
+  const isMappingContinueStep =
+    params?.stepId === '3' ||
+    (isDeltaIteration && (params?.stepId === '4' || params?.stepId === '5')) ||
+    (!isDeltaIteration && params?.stepId === '4');
+
   useEffect(() => {
     fetchProject();
   }, [selectedOrganisation?.value, params?.projectId]);
@@ -67,12 +81,18 @@ const MigrationFlowHeader = ({
   useEffect(() => {
     let newStepValue;
     
-    // Check conditions in priority order
-    if (newMigrationData?.legacy_cms?.projectStatus === 5 && newMigrationData?.migration_execution?.migrationCompleted) {
+    // Check conditions in priority order.
+    // "Restart Migration" only applies on the final Execute step once a migration has completed —
+    // not while navigating back through earlier (completed) steps in a delta iteration.
+    if (
+      params?.stepId === EXECUTE_MIGRATION_STEP &&
+      newMigrationData?.legacy_cms?.projectStatus === 5 &&
+      newMigrationData?.migration_execution?.migrationCompleted
+    ) {
       newStepValue = 'Restart Migration';
-    } else if (params?.stepId === '5') {
+    } else if (params?.stepId === EXECUTE_MIGRATION_STEP) {
       newStepValue = 'Start Migration';
-    } else if (params?.stepId === '3' || params?.stepId === '4') {
+    } else if (isMappingContinueStep) {
       newStepValue = 'Continue';
     } else {
       newStepValue = 'Save and Continue';
@@ -85,7 +105,7 @@ const MigrationFlowHeader = ({
   }, [params?.stepId, newMigrationData?.legacy_cms?.projectStatus, newMigrationData?.migration_execution?.migrationCompleted, newMigrationData?.stepValue, dispatch]);
 
   const isStep4AndNotMigrated =
-    params?.stepId === '4' &&
+    params?.stepId === TEST_MIGRATION_STEP &&
     !newMigrationData?.testStacks?.some(
       (stack) =>
         stack?.stackUid === newMigrationData?.test_migration?.stack_api_key && stack?.isMigrated
@@ -115,12 +135,31 @@ const MigrationFlowHeader = ({
     (finalExecutionStarted || newMigrationData?.migration_execution?.migrationStarted) &&
     !newMigrationData?.migration_execution?.migrationCompleted;
 
+  // Disable the Start Migration button while the start request is in flight / after a successful
+  // start (driven by the local finalExecutionStarted flag from the click handler, NOT by the
+  // migration-completed flag — so the live logs still show while migration runs).
+  const isStartMigrationDisabled =
+    params?.stepId === EXECUTE_MIGRATION_STEP &&
+    !!finalExecutionStarted &&
+    newMigrationData?.stepValue !== 'Restart Migration';
+
   const destinationStackMigrated =
-    params?.stepId === '5' &&
+    params?.stepId === EXECUTE_MIGRATION_STEP &&
     newMigrationData?.destination_stack?.migratedStacks?.includes(
       newMigrationData?.destination_stack?.selectedStack?.value
     );
   const isFileValidated = newMigrationData?.isContentMapperGenerated ? true : newMigrationData?.legacy_cms?.uploadedFile?.reValidate;
+
+  // Map Content Fields (step 3) empty-state handling:
+  // - Iteration 1 with no content types = genuine error → keep Continue disabled.
+  // - Iteration 2+ with no NEW content types = valid (nothing new to map) → Continue stays enabled.
+  // ContentMapper reports emptiness via hasNoContentTypes (its local fetch result), which is more
+  // accurate than isContentMapperGenerated (the project's mapper-id array can be non-empty while the
+  // resolved content-type list is empty).
+  const isContentMapperEmptyOnFirstIteration =
+    params?.stepId === '3' &&
+    !isDeltaIteration &&
+    newMigrationData?.hasNoContentTypes === true;
 
   return (
     <div className="d-flex align-items-center justify-content-between migration-flow-header">
@@ -141,6 +180,8 @@ const MigrationFlowHeader = ({
         isLoading={isLoading || newMigrationData?.isprojectMapped}
         disabled={
           isMigrationInProgress ||
+          isStartMigrationDisabled ||
+          isContentMapperEmptyOnFirstIteration ||
           (isProjectStatusThreeAndMapperNotGenerated ?
             isFileValidated :
             isStep4AndNotMigrated ||

--- a/ui/src/components/Stepper/HorizontalStepper/HorizontalStepper.tsx
+++ b/ui/src/components/Stepper/HorizontalStepper/HorizontalStepper.tsx
@@ -105,28 +105,39 @@ const HorizontalStepper = forwardRef(
       if (!Number.isNaN(stepIndex) && stepIndex >= 0 && stepIndex < steps?.length) {
         !newMigrationDataRef?.current?.isprojectMapped && setShowStep(stepIndex);
         setStepsCompleted((prev) => {
-          // Drop any completed steps at or beyond the current step so a restart
-          // (navigating back to an earlier step) un-fills the connectors ahead of it.
-          // Steps before the current one remain completed.
-          const updatedStepsCompleted = prev?.filter((i) => i < stepIndex);
+          // Completion is driven by the project's persisted current step, NOT by which step is
+          // currently being viewed. This lets the user navigate back to review an earlier step
+          // without un-filling the connectors for steps they've already completed.
+          // current_step is 1-based, so steps with index < (current_step - 1) are completed.
+          const currentStepNumber =
+            newMigrationData?.project_current_step ?? props?.projectData?.current_step ?? 1;
+
+          // Restart: when the project resets to step 1, all prior progress is cleared, so the
+          // accumulated completed-steps must reset too (don't carry the previous run's filled bar).
+          const previousCompleted = currentStepNumber <= 1 ? [] : (prev ?? []);
+
+          // Furthest progress = max of the persisted current step and the step being viewed
+          // (so navigating forward also fills as expected).
+          const completedThrough = Math.max(currentStepNumber - 1, stepIndex);
+          const completed: number[] = [];
+          for (let i = 0; i < completedThrough; i++) {
+            completed.push(i);
+          }
+
+          // Last step (Execute Migration) gets marked complete only once migration finishes.
+          const lastStepIndex = (steps?.length ?? 1) - 1;
           if (
-            stepIndex === 4 &&
+            stepIndex === lastStepIndex &&
             (props?.projectData?.isMigrationCompleted ||
               newMigrationData?.migration_execution?.migrationCompleted)
           ) {
-            if (!updatedStepsCompleted?.includes(4)) {
-              updatedStepsCompleted.push(4);
-            }
+            completed.push(lastStepIndex);
           }
-          for (let i = 0; i < stepIndex; i++) {
-            if (!updatedStepsCompleted?.includes(i)) {
-              updatedStepsCompleted?.push(i);
-            }
-          }
-          return updatedStepsCompleted;
+
+          return Array.from(new Set([...previousCompleted, ...completed]));
         });
       }
-    }, [stepId, newMigrationData?.migration_execution?.migrationCompleted]);
+    }, [stepId, newMigrationData?.migration_execution?.migrationCompleted, newMigrationData?.project_current_step]);
 
     useImperativeHandle(ref, () => ({
       handleStepChange: (currentStep: number) => {

--- a/ui/src/context/app/app.interface.ts
+++ b/ui/src/context/app/app.interface.ts
@@ -218,6 +218,9 @@ export interface INewMigration {
   settings:ISetting;
   iteration: number;
   stepValue?: string;
+  // True when the Map Content Fields step (step 3) has loaded but returned zero content types.
+  // Used to gate the step-3 Continue button: disabled on iteration 1 (error), enabled on iteration 2+.
+  hasNoContentTypes?: boolean;
 }
 
 export interface TestStacks {

--- a/ui/src/pages/Migration/index.tsx
+++ b/ui/src/pages/Migration/index.tsx
@@ -58,6 +58,7 @@ import HorizontalStepper from '../../components/Stepper/HorizontalStepper/Horizo
 import LegacyCms from '../../components/LegacyCms';
 import DestinationStackComponent from '../../components/DestinationStack';
 import ContentMapper from '../../components/ContentMapper';
+import EntryMapper from '../../components/ContentMapper/entryMapper';
 import TestMigration from '../../components/TestMigration';
 import MigrationExecution from '../../components/MigrationExecution';
 import SaveChangesModal from '../../components/Common/SaveChangesModal';
@@ -209,14 +210,27 @@ const Migration = () => {
       return;
     }
 
+    // Delta migration: the "Map Entry" flow step only exists from iteration 2 onwards.
+    // migrationSteps.json statically lists the 6-step (delta) layout, so on iteration 1 we
+    // drop the Map Entry step and renumber the steps after it so the side-nav names stay in
+    // sync with the 5-step createStepper() flow.
+    const iteration = newMigrationData?.iteration ?? 1;
+    const allFlowSteps: IFlowStep[] = validateArray(data?.all_steps)
+      ? iteration > 1
+        ? data?.all_steps
+        : data?.all_steps
+            ?.filter((step: IFlowStep) => step?.flow_id !== 'mapEntry')
+            ?.map((step: IFlowStep, index: number) => ({ ...step, name: `${index + 1}` }))
+      : data?.all_steps;
+
     //get Flow Steps and update it in APP Context
-    const currentFlowStep = validateArray(data?.all_steps)
-      ? data?.all_steps?.find((step: IFlowStep) => `${step.name}` === params?.stepId)
+    const currentFlowStep = validateArray(allFlowSteps)
+      ? allFlowSteps?.find((step: IFlowStep) => `${step.name}` === params?.stepId)
       : DEFAULT_IFLOWSTEP;
 
     dispatch(
       updateMigrationData({
-        allFlowSteps: data?.all_steps,
+        allFlowSteps: allFlowSteps,
         currentFlowStep: currentFlowStep,
         migration_steps_heading: data?.migration_steps_heading,
         settings: data?.settings
@@ -224,7 +238,7 @@ const Migration = () => {
     );
 
     await fetchProjectData();
-    const stepIndex = data?.all_steps?.findIndex(
+    const stepIndex = allFlowSteps?.findIndex(
       (step: IFlowStep) => `${step?.name}` === params?.stepId
     );
     setCurrentStepIndex(stepIndex !== -1 ? stepIndex : 0);
@@ -485,6 +499,11 @@ const Migration = () => {
     projectData: MigrationResponse,
     handleStepChange: (currentStep: number) => void
   ) => {
+    // Delta migration: the "Map Entry" step (and the 6-step flow) only exists from iteration 2
+    // onwards. Iteration 1 is the original 5-step flow with no entry mapping.
+    const iteration = projectData?.iteration ?? newMigrationData?.iteration ?? 1;
+    const isDeltaIteration = iteration > 1;
+
     const steps = [
       {
         data: (
@@ -514,14 +533,24 @@ const Migration = () => {
         id: '3',
         title: 'Map Content Fields'
       },
+      // Map Entry only from iteration 2+
+      ...(isDeltaIteration
+        ? [
+            {
+              data: <EntryMapper handleStepChange={handleStepChange} />,
+              id: '4',
+              title: 'Map Entry'
+            }
+          ]
+        : []),
       {
         data: <TestMigration />,
-        id: '4',
+        id: isDeltaIteration ? '5' : '4',
         title: 'Run Test Migration'
       },
       {
         data: <MigrationExecution handleStepChange={handleStepChange} />,
-        id: '5',
+        id: isDeltaIteration ? '6' : '5',
         title: 'Execute Migration'
       }
     ];
@@ -787,7 +816,21 @@ const Migration = () => {
   };
 
   /**
-   * Calls when click Continue button on Test Migration step and handles to proceed to Migration Execution
+   * Calls when click Continue button on Map Entry step (delta iteration only) and handles to
+   * proceed to Test Migration. Map Entry is step 4 (index 3), Test Migration is step 5 (index 4).
+   */
+  const handleOnClickMapEntry = async () => {
+    setIsLoading(false);
+    await updateCurrentStepData(selectedOrganisation.value, projectId);
+    handleStepChange(4);
+    const url = `/projects/${projectId}/migration/steps/5`;
+    navigate(url, { replace: true });
+  };
+
+  /**
+   * Calls when click Continue button on Test Migration step and handles to proceed to Migration Execution.
+   * Delta migration: Test Migration is step 5 / index 4 on iteration 2+ (Execute is step 6 / index 5),
+   * but step 4 / index 3 on iteration 1 (Execute is step 5 / index 4).
    */
   const handleOnClickTestMigration = async () => {
     setIsLoading(false);
@@ -796,8 +839,10 @@ const Migration = () => {
 
     const res = await updateCurrentStepData(selectedOrganisation.value, projectId);
     //if (res?.status === 200) {
-      handleStepChange(4);
-      const url = `/projects/${projectId}/migration/steps/5`;
+      const isDeltaIteration = (newMigrationData?.iteration ?? 1) > 1;
+      const executeStepIndex = isDeltaIteration ? 5 : 4;
+      handleStepChange(executeStepIndex);
+      const url = `/projects/${projectId}/migration/steps/${executeStepIndex + 1}`;
       navigate(url, { replace: true });
     //}
   };
@@ -809,6 +854,9 @@ const Migration = () => {
     setIsLoading(true);
 
     if (newMigrationData?.stepValue !== 'Restart Migration') {
+      // Disable the Start Migration button immediately on click; keep it disabled on success
+      // (migration is now running) and only re-enable it if the API call fails.
+      setDisableMigration(true);
       try {
         const migrationRes = await startMigration(
           newMigrationData?.destination_stack?.selectedOrg?.value,
@@ -816,7 +864,6 @@ const Migration = () => {
         );
 
         if (migrationRes?.status === 200) {
-          setDisableMigration(true);
           const newMigrationDataObj: INewMigration = {
             ...newMigrationData,
             migration_execution: {
@@ -835,6 +882,7 @@ const Migration = () => {
             type: 'message'
           });
         } else {
+          setDisableMigration(false);
           Notification({
             notificationContent: {
               text: migrationRes?.data?.error?.message || 'Failed to start migration'
@@ -844,6 +892,7 @@ const Migration = () => {
         }
       } catch (error) {
         console.error(error);
+        setDisableMigration(false);
         Notification({
           notificationContent: { text: 'Failed to start migration' },
           type: 'error'
@@ -913,10 +962,15 @@ const Migration = () => {
     dispatch(updateNewMigrationData(newMigrationDataObj));
   };
 
+  // CTA handlers indexed by step position. The Map Entry step (and its handler) only exists from
+  // iteration 2 onwards, so it is inserted between Content Mapper and Test Migration only then —
+  // keeping this array aligned with the iteration-aware createStepper() flow.
+  const isDeltaIteration = (newMigrationData?.iteration ?? 1) > 1;
   const handleOnClickFunctions = [
     handleOnClickLegacyCms,
     handleOnClickDestinationStack,
     handleOnClickContentMapper,
+    ...(isDeltaIteration ? [handleOnClickMapEntry] : []),
     handleOnClickTestMigration,
     handleOnClickMigrationExecution
   ];

--- a/ui/src/pages/Migration/index.tsx
+++ b/ui/src/pages/Migration/index.tsx
@@ -210,11 +210,18 @@ const Migration = () => {
       return;
     }
 
+    // Fetch project data FIRST so the side-nav is built from the authoritative iteration.
+    // On a hard reload/deep link, redux's newMigrationData.iteration is still the default (1)
+    // until this resolves — building allFlowSteps off stale redux would render the 5-step nav
+    // even for an iteration 2+ project and never recompute. fetchProjectData returns the
+    // resolved iteration so we don't depend on the async redux update landing first.
+    const resolvedIteration = await fetchProjectData();
+
     // Delta migration: the "Map Entry" flow step only exists from iteration 2 onwards.
     // migrationSteps.json statically lists the 6-step (delta) layout, so on iteration 1 we
     // drop the Map Entry step and renumber the steps after it so the side-nav names stay in
     // sync with the 5-step createStepper() flow.
-    const iteration = newMigrationData?.iteration ?? 1;
+    const iteration = resolvedIteration ?? newMigrationData?.iteration ?? 1;
     const allFlowSteps: IFlowStep[] = validateArray(data?.all_steps)
       ? iteration > 1
         ? data?.all_steps
@@ -237,7 +244,6 @@ const Migration = () => {
       })
     );
 
-    await fetchProjectData();
     const stepIndex = allFlowSteps?.findIndex(
       (step: IFlowStep) => `${step?.name}` === params?.stepId
     );
@@ -310,7 +316,7 @@ const Migration = () => {
   /**
    * Fetch the project data
    */
-  const fetchProjectData = async () => {
+  const fetchProjectData = async (): Promise<number | undefined> => {
   if (isEmptyString(selectedOrganisation?.value) || isEmptyString(params?.projectId)) return;
   setIsProjectMapper(true);
   const migrationData = await getMigrationData(selectedOrganisation?.value, params?.projectId ?? '');
@@ -490,6 +496,10 @@ const Migration = () => {
 
     dispatch(updateNewMigrationData(projectMapper));
     setIsProjectMapper(false);
+
+    // Return the authoritative iteration so the caller can build the side-nav without waiting
+    // for the redux update above to land.
+    return projectData?.iteration ?? 1;
   };
 
   /**

--- a/ui/src/services/api/migration.service.ts
+++ b/ui/src/services/api/migration.service.ts
@@ -113,12 +113,17 @@ export const getContentTypes = (
   projectId: string,
   skip: number,
   limit: number,
-  searchText: string
+  searchText: string,
+  filter?: 'new' | 'old'
 ) => {
   try {
     const encodedSearchText = encodeURIComponent(searchText);
+    // Delta migration (iteration > 1): 'new' → first-time content types for Step 3 (field
+    // mapping), 'old' → already-migrated content types for Step 4 (entry mapping). Ignored on
+    // iteration 1 by the backend.
+    const filterQuery = filter ? `&filter=${filter}` : '';
     return getCall(
-      `${API_VERSION}/mapper/contentTypes/${projectId}/${skip}/${limit}/${encodedSearchText}?`,
+      `${API_VERSION}/mapper/contentTypes/${projectId}/${skip}/${limit}/${encodedSearchText}?${filterQuery}`,
       options()
     );
   } catch (error) {

--- a/ui/src/services/api/service.interface.ts
+++ b/ui/src/services/api/service.interface.ts
@@ -37,6 +37,7 @@ export interface MigrationResponse {
   isMigrationStarted: boolean;
   isMigrationCompleted: boolean;
   migration_execution: boolean;
+  iteration?: number;
 }
 
 export interface LegacyCms {

--- a/ui/src/utilities/constants.ts
+++ b/ui/src/utilities/constants.ts
@@ -197,3 +197,15 @@ export const EXECUTION_LOGS_UI_TEXT = {
 export const EXECUTION_LOGS_ERROR_TEXT = {
   ERROR: 'Error in Getting Migration Logs'
 }
+
+// Content Mapper (Map Content Fields step) empty-state text.
+// Delta migration (iteration > 1): an empty list means there are no NEW content types — valid,
+// the user can continue. Iteration 1: an empty list means content-mapper generation failed.
+export const CONTENT_MAPPER_EMPTY_STATE = {
+  NO_NEW_CONTENT_TYPES_HEADING: 'No new content types',
+  NO_NEW_CONTENT_TYPES_DESCRIPTION:
+    'There are no new content types in this file. You can still continue.',
+  NO_CONTENT_TYPES_HEADING: 'No Content Types available',
+  NO_CONTENT_TYPES_DESCRIPTION:
+    'There is something error occured while generating content mapper. Please go to Legacy Cms step and validate the file again.'
+}

--- a/ui/src/utilities/constants.ts
+++ b/ui/src/utilities/constants.ts
@@ -207,5 +207,5 @@ export const CONTENT_MAPPER_EMPTY_STATE = {
     'There are no new content types in this file. You can still continue.',
   NO_CONTENT_TYPES_HEADING: 'No Content Types available',
   NO_CONTENT_TYPES_DESCRIPTION:
-    'There is something error occured while generating content mapper. Please go to Legacy Cms step and validate the file again.'
+    'An error occurred while generating the content mapper. Please go to the Legacy CMS step and validate the file again.'
 }


### PR DESCRIPTION
## 🔗 Jira Ticket

[CMG-997](https://contentstack.atlassian.net/browse/CMG-997)

---

## 📋 PR Type

- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

**New "Map Entry" step (delta migration, iteration 2+)**
- Split the migration flow into 6 steps from iteration 2 onwards: `Legacy CMS → Destination Stack → Map Content Fields → Map Entry → Test Migration → Execute`. Iteration 1 stays the original 5-step flow (no Map Entry).
- **Step 3 (Map Content Fields)** now shows only **new** content types (not migrated in the previous iteration) — re-mapping already-migrated types risks data loss.
- **Step 4 (Map Entry)** is a new standalone screen that shows only **already-migrated** content types that have entry mappings, and lets the user select entries to update.

**Single-route, filter-based content type fetch**
- `getContentTypes` takes a `filter` query param (`new` | `old`) instead of a new endpoint. On iteration 2+ it diffs the current vs previous iteration's `contentTypesMapper.json` by `otherCmsUid` to return the new-only or old-only slice. Iteration 1 is untouched.
- Map Entry list excludes content types with no `entryMapping`, and derives each content type's status icon (green "Updated" / blue "Mapped") from the saved `isUpdate` state so it persists correctly across reloads.

**Iteration-aware step numbering**
- Backend `current_step` state machine is now iteration-aware (`DELTA_STEPPER_STEPS` adds Map Entry as step 4, shifting Testing → 5, Execute → 6 on delta iterations).
- Frontend stepper, CTA button states, step gates (`project_current_step`), and the side-nav (`migrationSteps.json`) all resolve step numbers by iteration.

**Stepper / navigation fixes**
- Step completion is driven by the persisted `current_step`, so navigating back to review a completed step no longer resets the progress bar, and completed steps stay navigable.
- Restart resets the progress bar correctly; the Start Migration button is disabled via the actual API call (not the completion flag) so live logs still stream.
- Friendlier empty state on delta iterations ("No new content types — you can still continue") with the Continue button enabled and the "Go to Legacy CMS" action hidden.

**Bug fix — entry update data loss**
- `removeEntriesFromDatabase` previously deleted **every** entry present in the entry mapper, even ones never migrated (no `contentstackEntryUid`), silently dropping them. Now it only removes entries that already exist in Contentstack (have a `contentstackEntryUid`); `isUpdate` ones are collected for update, the rest are left to be created fresh.

**Tests**
- Added unit tests for the `updateEntryCli` service (basic-auth & OAuth paths, missing stack key, auth errors, stdout/stderr log-level classification, non-zero exit handling, warning mapping).

### Why?

Delta (re-)migrations need to map and update entries of already-migrated content types across iterations without losing data or re-mapping content that was already migrated. The previous flow had no Map Entry step, no iteration-aware step numbering, and a bug that dropped never-migrated entries during update.

---

## 🧩 Affected Areas

- [x] `api` — Node.js backend
- [x] `ui` — React frontend
- [ ] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

**Iteration 1 (fresh migration):**
1. Run a migration end to end — confirm the flow has **5 steps** (no Map Entry).
2. On Map Content Fields, confirm all content types show; empty list shows the error state with Continue disabled.

**Iteration 2+ (delta / restart):**
1. Restart a completed migration (iteration bumps) and confirm the flow now has **6 steps** with Map Entry as step 4.
2. **Step 3** shows only NEW content types; if none, the friendly "No new content types" state shows with Continue enabled.
3. **Step 4 (Map Entry)** shows only already-migrated content types that have entries; select entries and click Save — the content type icon turns green.
4. Reload the page — content type icons keep the correct green/blue status without needing to open each one.
5. Walk all 6 steps forward/back — the progress bar doesn't reset, completed steps are navigable, and `current_step` in the DB reaches 6 on Execute.
6. Start a migration — live logs stream and the Start button is disabled while running.

**Entry update data-loss fix:**
7. Have an entry that was NOT migrated in iteration 1 — confirm it gets **created** this iteration (not silently dropped). Entries marked `isUpdate` with a Contentstack uid get **updated**.

**Tests:**
8. `cd api && npm test` — `updateEntryCli.service.test.ts` passes.

**Expected result:** Iteration 1 = 5 steps unchanged; iteration 2+ = 6 steps with correct new/old content type splitting, persistent status icons, no progress-bar resets, and no entry data loss.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

-

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `feature/`, `bugfix/`, or `hotfix/` + 5–30 lowercase chars
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added — N/A (no new env vars)
- [x] No sensitive credentials or secrets committed
- [x] Existing tests pass locally (`npm test`)
- [x] New tests written — added `updateEntryCli.service.test.ts`
- [ ] `README.md` / docs updated if behaviour changed — N/A
- [x] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

- The new/old content type split is driven by a single `getContentTypes?filter=new|old` param + a per-iteration diff on `contentTypesMapper.json` — no new endpoint.
- Step numbering is iteration-aware in **two** places that must stay in sync: `createStepper()` (UI) and `migrationSteps.json` `all_steps` (side-nav), plus the backend `STEPPER_STEPS` / `DELTA_STEPPER_STEPS`.
- Please double-check the `entry-update.utils.ts` delete rule — entries are removed from import data only when they have a `contentstackEntryUid` (exist in CS); never-migrated entries are intentionally kept to be created.

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) · [Issues](https://github.com/contentstack/migration-v2/issues)