### PR TITLE
fix(ui): rework step 4 mapping + fix legacy CMS file-format validation

### DIFF
--- a/ui/src/components/ContentMapper/assetMapper.tsx
+++ b/ui/src/components/ContentMapper/assetMapper.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   InfiniteScrollTable,
   Notification,
+  EmptyState,
 } from '@contentstack/venus-components';
 
 // Services
@@ -17,9 +18,15 @@ import {
 // Redux
 import { RootState } from '../../store';
 
+// Utilities
+import { ASSET_MAPPER_EMPTY_STATE } from '../../utilities/constants';
+
 // Interface
 import { AssetMapperType, TableTypes, UidMap } from './contentMapper.interface';
 import { ItemStatusMapProp } from '@contentstack/venus-components/build/components/Table/types';
+
+// Styles and Assets
+import { NoDataFound } from '../../common/assets';
 
 // Pure logic (unit-tested in assetMapper.utils.test.ts)
 import {
@@ -53,6 +60,9 @@ const AssetMapper = ({
   const [rowIds, setRowIds] = useState<Record<string, boolean>>({});
   const [persistedRowIds, setPersistedRowIds] = useState<Record<string, boolean>>({});
   const [isLoadingSaveButton, setisLoadingSaveButton] = useState<boolean>(false);
+  // True once the initial fetch has settled — used to gate the empty state so it
+  // doesn't flash before assets have loaded.
+  const [hasFetched, setHasFetched] = useState<boolean>(false);
 
   useEffect(() => {
     fetchAssets('');
@@ -88,8 +98,10 @@ const AssetMapper = ({
       setPersistedRowIds(initialSelected);
       setTotalCounts(total);
       onCountChange?.(total);
+      setHasFetched(true);
     } catch (error) {
       console.error('fetchAssets -> error', error);
+      setHasFetched(true);
     }
   };
 
@@ -275,44 +287,60 @@ const AssetMapper = ({
   ];
 
   return (
-    <div className='entry-mapper-container'>
-      <InfiniteScrollTable
-        key={'asset-mapper-table'}
-        loading={loading}
-        canSearch={true}
-        totalCounts={Math.max(0, totalCounts)}
-        data={[...tableData]}
-        columns={columns}
-        uniqueKey={'id'}
-        isRowSelect={true}
-        fullRowSelect={true}
-        itemStatusMap={itemStatusMap}
-        fetchTableData={fetchData}
-        loadMoreItems={loadMoreItems}
-        tableHeight={tableHeight}
-        equalWidthColumns={false}
-        columnSelector={false}
-        initialSelectedRowIds={rowIds}
-        itemSize={80}
-        getSelectedRow={handleSelectedAssets}
-        rowSelectCheckboxProp={{ key: '_canSelect', value: true }}
-        name={{
-          singular: '',
-          plural: `${totalCounts === 0 ? 'Count' : ''}`
-        }}
-      />
-      <div className="mapper-footer">
-        <div>Total Assets: <strong>{totalCounts}</strong></div>
-        <Button
-          className="saveButton"
-          onClick={handleSaveAssets}
+    <div className="step-container">
+      {(hasFetched && !loading && totalCounts === 0) ?
+        <EmptyState
+          forPage="emptyStateV2"
+          heading={<div className="empty_search_heading">{ASSET_MAPPER_EMPTY_STATE.NO_ASSETS_HEADING}</div>}
+          description={
+            <div className="empty_search_description">
+              {ASSET_MAPPER_EMPTY_STATE.NO_ASSETS_DESCRIPTION}
+            </div>
+          }
+          className="mapper-emptystate mapper-emptystate--centered"
+          img={NoDataFound}
           version="v2"
-          disabled={newMigrationData?.project_current_step > 4}
-          isLoading={isLoadingSaveButton}
-        >
-          Save
-        </Button>
-      </div>
+          testId="no-results-found-page"
+        /> :
+        <div className='entry-mapper-container'>
+          <InfiniteScrollTable
+            key={'asset-mapper-table'}
+            loading={loading}
+            canSearch={true}
+            totalCounts={Math.max(0, totalCounts)}
+            data={[...tableData]}
+            columns={columns}
+            uniqueKey={'id'}
+            isRowSelect={true}
+            fullRowSelect={true}
+            itemStatusMap={itemStatusMap}
+            fetchTableData={fetchData}
+            loadMoreItems={loadMoreItems}
+            tableHeight={tableHeight}
+            equalWidthColumns={false}
+            columnSelector={false}
+            initialSelectedRowIds={rowIds}
+            itemSize={80}
+            getSelectedRow={handleSelectedAssets}
+            rowSelectCheckboxProp={{ key: '_canSelect', value: true }}
+            name={{
+              singular: '',
+              plural: `${totalCounts === 0 ? 'Count' : ''}`
+            }}
+          />
+          <div className="mapper-footer">
+            <div>Total Assets: <strong>{totalCounts}</strong></div>
+            <Button
+              className="saveButton"
+              onClick={handleSaveAssets}
+              version="v2"
+              disabled={newMigrationData?.project_current_step > 4}
+              isLoading={isLoadingSaveButton}
+            >
+              Save
+            </Button>
+          </div>
+        </div>}
     </div>
   );
 };

--- a/ui/src/components/ContentMapper/entryAssetMapper.tsx
+++ b/ui/src/components/ContentMapper/entryAssetMapper.tsx
@@ -1,0 +1,58 @@
+// Libraries
+import { useState } from 'react';
+import { Button } from '@contentstack/venus-components';
+
+// Components
+import EntryMapper from './entryMapper';
+import AssetMapper from './assetMapper';
+
+// Styles
+import './index.scss';
+
+interface entryAssetMapperProps {
+  handleStepChange: (currentStep: number) => void;
+}
+
+/**
+ * Step 4 — Map Entry / Map Asset (delta migration).
+ * Wraps the standalone Entry and Asset mappers behind an Entries / Assets toggle.
+ * Both tabs are always available: the Entry mapper shows "no entries available" and the
+ * Asset mapper shows "no assets available" when their respective lists are empty.
+ */
+const EntryAssetMapper = ({ handleStepChange }: entryAssetMapperProps) => {
+  const [mapperView, setMapperView] = useState<'entries' | 'assets'>('entries');
+
+  const calcHeight = () => window.innerHeight - 361;
+  const tableHeight = calcHeight();
+
+  return (
+    <div className="step-container">
+      <div className="mapper-view-toggle">
+        <Button
+          buttonType={mapperView === 'entries' ? 'secondary' : 'light'}
+          version="v2"
+          size="small"
+          onClick={() => setMapperView('entries')}
+        >
+          Entries
+        </Button>
+        <Button
+          buttonType={mapperView === 'assets' ? 'secondary' : 'light'}
+          version="v2"
+          size="small"
+          onClick={() => setMapperView('assets')}
+        >
+          Assets
+        </Button>
+      </div>
+
+      {mapperView === 'assets' ? (
+        <AssetMapper tableHeight={tableHeight} />
+      ) : (
+        <EntryMapper handleStepChange={handleStepChange} />
+      )}
+    </div>
+  );
+};
+
+export default EntryAssetMapper;

--- a/ui/src/components/ContentMapper/entryAssetMapper.tsx
+++ b/ui/src/components/ContentMapper/entryAssetMapper.tsx
@@ -26,7 +26,11 @@ const EntryAssetMapper = ({ handleStepChange }: entryAssetMapperProps) => {
   const tableHeight = calcHeight();
 
   return (
-    <div className="step-container">
+    // Plain flex-column wrapper — NOT .step-container. Both child mappers render their own
+    // .step-container (height: 100%), so reusing it here would nest two full-height flex
+    // containers around the toggle and clip the table. This wrapper just stacks the toggle
+    // above the child and lets the child own the height.
+    <div className="entry-asset-mapper">
       <div className="mapper-view-toggle">
         <Button
           buttonType={mapperView === 'entries' ? 'secondary' : 'light'}

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -30,7 +30,7 @@ import { RootState } from '../../store';
 import { updateMigrationData, updateNewMigrationData } from '../../store/slice/migrationDataSlice';
 
 // Utilities
-import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping } from '../../utilities/constants';
+import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping, ENTRY_MAPPER_EMPTY_STATE } from '../../utilities/constants';
 import { validateArray } from '../../utilities/functions';
 
 // Interface
@@ -497,10 +497,6 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
   const calcHeight = () => window.innerHeight - 361;
   const tableHeight = calcHeight();
 
-  const modalProps = {
-    body: 'An error occurred while generating the content mapper. Please go to the Legacy CMS step and validate the file again.',
-  };
-
   return (
     isLoading || newMigrationData?.isprojectMapped
       ? <div className="loader-container">
@@ -684,35 +680,14 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
           </div> :
           <EmptyState
             forPage="emptyStateV2"
-            heading={<div className="empty_search_heading">No Content Types available</div>}
+            heading={<div className="empty_search_heading">{ENTRY_MAPPER_EMPTY_STATE.NO_ENTRIES_HEADING}</div>}
             description={
               <div className="empty_search_description">
-                {modalProps?.body}
+                {ENTRY_MAPPER_EMPTY_STATE.NO_ENTRIES_DESCRIPTION}
               </div>
             }
-            className="mapper-emptystate"
+            className="mapper-emptystate mapper-emptystate--centered"
             img={NoDataFound}
-            actions={
-              <Button buttonType="secondary" size="small" version="v2"
-                onClick={() => {
-                  const newMigrationDataObj: INewMigration = {
-                    ...newMigrationData,
-                    legacy_cms: {
-                      ...newMigrationData?.legacy_cms,
-                      uploadedFile: {
-                        ...newMigrationData?.legacy_cms?.uploadedFile,
-                        reValidate: true,
-                        buttonClicked: true,
-                      }
-                    }
-                  };
-                  dispatch(updateNewMigrationData(newMigrationDataObj));
-                  handleStepChange(0);
-                  const url = `/projects/${projectId}/migration/steps/1`;
-                  navigate(url, { replace: true });
-                }}
-                className='ml-10'>Go to Legacy CMS</Button>
-            }
             version="v2"
             testId="no-results-found-page"
           />}

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -463,6 +463,21 @@ div .table-row {
   padding-bottom: 70px;
 }
 
+// Step 4 wrapper: toggle stacked above the active mapper. Fills its parent and lets the
+// child .step-container take the remaining height (avoids nesting two height:100% containers).
+.entry-asset-mapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+
+  // The active child mapper (its own .step-container) fills the space left by the toggle.
+  > .step-container {
+    flex: 1;
+    min-height: 0;
+  }
+}
+
 // Entries / Assets switch shown on delta iterations
 .mapper-view-toggle {
   display: flex;

--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -85,8 +85,6 @@ import {
 // Styles and Assets
 import './index.scss';
 import { NoDataFound, SCHEMA_PREVIEW } from '../../common/assets';
-import EntryMapper from './entryMapper';
-import AssetMapper from './assetMapper';
 
 const FIELD_MAP_MENU_VIEW_MARGIN = 8;
 const FIELD_MAP_MENU_HYSTERESIS = 36;
@@ -568,8 +566,6 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
   const [isAllCheck, setIsAllCheck] = useState<boolean>(false);
   const [isResetFetch, setIsResetFetch] = useState<boolean>(false);
   const [iterationCount, setIterationCount] = useState<number>(newMigrationData?.iteration);
-  const [mapperView, setMapperView] = useState<'entries' | 'assets'>('entries');
-  const [assetCount, setAssetCount] = useState<number>(0);
 
   /** ALL HOOKS Here */
   const { projectId = '' } = useParams();
@@ -3298,31 +3294,9 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
             {/* Content Types List */}
             <div className="content-types-list-wrapper">
               <div className="content-types-list-header d-flex align-items-center justify-content-between">
-                {mapperView === 'assets'
-                  ? <h2>{`Assets (${assetCount})`}</h2>
-                  : (contentTypesHeading && <h2>{`${contentTypesHeading} (${contentTypes && count})`}</h2>)}
+                {contentTypesHeading && <h2>{`${contentTypesHeading} (${contentTypes && count})`}</h2>}
               </div>
 
-              <div className='mapper-view-toggle'>
-                <Button
-                  buttonType={mapperView === 'entries' ? 'secondary' : 'light'}
-                  version="v2"
-                  size="small"
-                  onClick={() => setMapperView('entries')}
-                >
-                  Entries
-                </Button>
-                <Button
-                  buttonType={mapperView === 'assets' ? 'secondary' : 'light'}
-                  version="v2"
-                  size="small"
-                  onClick={() => setMapperView('assets')}
-                >
-                  Assets
-                </Button>
-              </div>
-
-              {mapperView !== 'assets' && (<>
               <div className='ct-search-wrapper'>
                 <div className='d-flex align-items-center'>
                   <Search
@@ -3426,18 +3400,11 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                 </div>
                 : <div className='no-content'>No Content Types Found.</div>
               }
-              </>)}
             </div>
 
             {/* Content Type Fields */}
             <div className="content-types-fields-wrapper">
               <div className="table-wrapper" ref={tableWrapperRef}>
-                <div>
-                    {mapperView === 'assets' ? (
-                      <AssetMapper tableHeight={tableHeight} onCountChange={setAssetCount} />
-                    ) : isDeltaIteration ? (
-                      <EntryMapper handleStepChange={handleStepChange} />
-                    ) : (
                   <div>
                 <InfiniteScrollTable
                   loading={loading}
@@ -3518,9 +3485,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                   </div>
                 )}
                 </div>
-                )}
                 </div>
-            </div>
             </div>
           </div> :
           <EmptyState

--- a/ui/src/components/LegacyCms/Actions/LoadFileFormat.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadFileFormat.tsx
@@ -88,10 +88,13 @@ const LoadFileFormat = (_props: LoadFileFormatProps) => {
 
     // Only dispatch when the format actually changed, to avoid a render loop.
     if (newMigrationData?.legacy_cms?.selectedFileFormat?.fileformat_id?.toLowerCase() !== extractedFormat?.toLowerCase()) {
+      // Read the latest state from the ref (kept in sync above) rather than the effect's
+      // closure, so narrowing the deps below doesn't dispatch a stale snapshot.
+      const latest = newMigrationDataRef.current;
       dispatch(updateNewMigrationData({
-        ...newMigrationData,
+        ...latest,
         legacy_cms: {
-          ...newMigrationData?.legacy_cms,
+          ...latest?.legacy_cms,
           selectedFileFormat: fileFormatObj
         }
       }));
@@ -99,7 +102,16 @@ const LoadFileFormat = (_props: LoadFileFormatProps) => {
 
     setFileIcon(fileFormatObj?.title);
     setFileDisplayTitle(getDisplayTitle(fileFormatObj?.title));
-  }, [newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath, dispatch, newMigrationData]);
+    // Depend only on the fields this effect actually reads — the uploaded file path and the
+    // current format. Using the whole newMigrationData object re-ran this on every migration
+    // state change (repeatedly calling the setters). The dispatch reads newMigrationdata via a
+    // ref-fresh closure, so it isn't needed in the deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath,
+    newMigrationData?.legacy_cms?.selectedFileFormat?.fileformat_id,
+    newMigrationData?.legacy_cms?.selectedFileFormat?.title
+  ]);
 
   // Validate the uploaded file's format against the selected CMS's allowed formats.
   // This lives here (not in CMS selection) because the error is about the uploaded

--- a/ui/src/components/LegacyCms/Actions/LoadFileFormat.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadFileFormat.tsx
@@ -4,11 +4,17 @@ import { Icon, TextInput } from '@contentstack/venus-components';
 import { useDispatch, useSelector } from 'react-redux';
 
 // Utilities
-import { isEmptyString, getFileExtension } from '../../../utilities/functions';
+import { isEmptyString, getFileExtension, validateArray } from '../../../utilities/functions';
 
 // Components
 import { RootState } from '../../../store';
 import { updateNewMigrationData } from '../../../store/slice/migrationDataSlice';
+
+// Interface
+import { ICardType } from '../../../components/Common/Card/card.interface';
+
+// Style
+import '../legacyCms.scss';
 
 interface LoadFileFormatProps {
   stepComponentProps?: () => {};
@@ -33,46 +39,104 @@ const LoadFileFormat = (_props: LoadFileFormatProps) => {
   const [fileIcon, setFileIcon]  = useState(newMigrationDataRef?.current?.legacy_cms?.selectedFileFormat?.title);
   const [fileDisplayTitle, setFileDisplayTitle] = useState(getDisplayTitle(newMigrationDataRef?.current?.legacy_cms?.selectedFileFormat?.title));
 
+  // Error state for when the uploaded file's format isn't supported by the selected CMS
+  const [isError, setIsError] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
   /****  ALL USEEffects  HERE  ****/
   // Update ref whenever newMigrationData changes
   useEffect(() => {
     newMigrationDataRef.current = newMigrationData;
   }, [newMigrationData]);
 
-  // Handle file format extraction - RUN IMMEDIATELY ON MOUNT AND WHEN DATA CHANGES
+  // Handle file format extraction - RUN IMMEDIATELY ON MOUNT AND WHENEVER THE FILE PATH CHANGES.
+  // The displayed format is always derived from the ACTUAL uploaded file extension, never from a
+  // stale selectedFileFormat (which gets pre-seeded to the CMS default on CMS selection). This is
+  // why editing the file path (e.g. zip → json) now updates the label, icon, and Redux in sync.
   useEffect(() => {
     const filePath = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath || '';
     const currentFormat = newMigrationData?.legacy_cms?.selectedFileFormat?.title;
-    
-    // If we have a file path but no format, extract it NOW
-    if (!isEmptyString(filePath) && isEmptyString(currentFormat)) {
-      const extractedFormat = getFileExtension(filePath);
-      
-      if (!isEmptyString(extractedFormat)) {
-        const fileFormatObj = {
-          description: '',
-          fileformat_id: extractedFormat,
-          group_name: extractedFormat,
-          isactive: true,
-          title: extractedFormat === 'zip' ? 'Zip' : extractedFormat.toUpperCase()
-        };
-                
-        dispatch(updateNewMigrationData({
-          ...newMigrationData,
-          legacy_cms: {
-            ...newMigrationData?.legacy_cms,
-            selectedFileFormat: fileFormatObj
-          }
-        }));
-        
-        setFileIcon(fileFormatObj?.title);
-        setFileDisplayTitle(getDisplayTitle(fileFormatObj?.title));
+
+    // No file yet — fall back to whatever format is already in Redux (e.g. SQL/directory CMS types
+    // that don't carry a localPath).
+    if (isEmptyString(filePath)) {
+      if (!isEmptyString(currentFormat)) {
+        setFileIcon(currentFormat);
+        setFileDisplayTitle(getDisplayTitle(currentFormat));
       }
-    } else if (!isEmptyString(currentFormat)) {
-      setFileIcon(currentFormat);
-      setFileDisplayTitle(getDisplayTitle(currentFormat));
+      return;
     }
-  }, [newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath, newMigrationData?.legacy_cms?.selectedFileFormat, dispatch, newMigrationData]);
+
+    const extractedFormat = getFileExtension(filePath);
+
+    // Couldn't read a valid extension — keep displaying the existing format rather than blanking it.
+    if (isEmptyString(extractedFormat)) {
+      if (!isEmptyString(currentFormat)) {
+        setFileIcon(currentFormat);
+        setFileDisplayTitle(getDisplayTitle(currentFormat));
+      }
+      return;
+    }
+
+    const fileFormatObj = {
+      description: '',
+      fileformat_id: extractedFormat,
+      group_name: extractedFormat,
+      isactive: true,
+      title: extractedFormat === 'zip' ? 'Zip' : extractedFormat.toUpperCase()
+    };
+
+    // Only dispatch when the format actually changed, to avoid a render loop.
+    if (newMigrationData?.legacy_cms?.selectedFileFormat?.fileformat_id?.toLowerCase() !== extractedFormat?.toLowerCase()) {
+      dispatch(updateNewMigrationData({
+        ...newMigrationData,
+        legacy_cms: {
+          ...newMigrationData?.legacy_cms,
+          selectedFileFormat: fileFormatObj
+        }
+      }));
+    }
+
+    setFileIcon(fileFormatObj?.title);
+    setFileDisplayTitle(getDisplayTitle(fileFormatObj?.title));
+  }, [newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath, dispatch, newMigrationData]);
+
+  // Validate the uploaded file's format against the selected CMS's allowed formats.
+  // This lives here (not in CMS selection) because the error is about the uploaded
+  // file, not the CMS the user picked.
+  //
+  // We derive the format from the actual uploaded file extension — NOT from
+  // selectedFileFormat, which gets pre-seeded to the CMS's default format on CMS
+  // selection and would otherwise mask a mismatching upload (e.g. CMS default "zip"
+  // hiding a ".pdf" upload).
+  useEffect(() => {
+    const selectedCms = newMigrationData?.legacy_cms?.selectedCms;
+    const allowedFormats = selectedCms?.allowed_file_formats;
+    const filePath = newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath || '';
+    const uploadedFormat = getFileExtension(filePath);
+
+    // Nothing to validate until we have both a CMS with allowed formats and an uploaded file.
+    if (!validateArray(allowedFormats) || isEmptyString(uploadedFormat)) {
+      setIsError(false);
+      setErrorMessage('');
+      return;
+    }
+
+    const isSupported = allowedFormats?.some(
+      (format: ICardType) => format?.fileformat_id?.toLowerCase() === uploadedFormat?.toLowerCase()
+    );
+
+    if (isSupported) {
+      setIsError(false);
+      setErrorMessage('');
+    } else {
+      setIsError(true);
+      setErrorMessage('Current file format is not supported for the selected CMS. Please upload a file with a supported format.');
+    }
+  }, [
+    newMigrationData?.legacy_cms?.selectedCms,
+    newMigrationData?.legacy_cms?.uploadedFile?.file_details?.localPath
+  ]);
 
   return (
     <div className="p-3">
@@ -95,6 +159,9 @@ const LoadFileFormat = (_props: LoadFileFormatProps) => {
             disabled={true}
           />
         </label>
+        {isError && (
+          <div className="px-3 py-1 fs-6 errorMessage">{errorMessage}</div>
+        )}
       </div>
     </div>
   );

--- a/ui/src/components/LegacyCms/Actions/LoadSelectCms.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadSelectCms.tsx
@@ -9,7 +9,7 @@ import { getConfig } from '../../../services/api/upload.service';
 import { isEmptyString, validateArray } from '../../../utilities/functions';
 
 // Interface
-import { defaultCardType, ICardType } from '../../../components/Common/Card/card.interface';
+import { defaultCardType } from '../../../components/Common/Card/card.interface';
 import { DEFAULT_CMS_TYPE, ICMSType, INewMigration } from '../../../context/app/app.interface';
 
 // Components
@@ -103,22 +103,12 @@ const LoadSelectCms = (props: LoadSelectCmsProps) => {
         );
         setIsLoading(false);
 
-        const currentFormat = newMigrationData?.legacy_cms?.selectedFileFormat?.title;
-        
         // Check if filter returned any results
         if (filteredCmsData?.length > 0) {
-          filteredCmsData?.forEach((data: ICMSType) => {
-            // Check if filter returned any results and if the file format is not the same as the current format
-            if (data?.allowed_file_formats?.some((format: ICardType) => format?.fileformat_id?.toLowerCase() !== currentFormat?.toLowerCase())) {
-              setIsError(true);
-              setErrorMessage('Current file format is not supported for this CMS. Please add the correct CMS');
-              setCmsData(filteredCmsData);
-            } else if (data?.allowed_file_formats?.some((format: ICardType) => format?.fileformat_id?.toLowerCase() === currentFormat?.toLowerCase())) {
-              setIsError(false);
-              setErrorMessage('');
-              setCmsData(filteredCmsData);
-            }
-          });
+          // File-format compatibility is validated in LoadFileFormat, not here.
+          setIsError(false);
+          setErrorMessage('');
+          setCmsData(filteredCmsData);
         } else {
           // cmstype is not empty but no matches found
           setIsError(true);

--- a/ui/src/components/MigrationFlowHeader/index.tsx
+++ b/ui/src/components/MigrationFlowHeader/index.tsx
@@ -123,11 +123,19 @@ const MigrationFlowHeader = ({
     newMigrationData?.legacy_cms?.projectStatus === 3 &&
     newMigrationData?.legacy_cms?.uploadedFile?.buttonClicked 
 
+  // A freshly restarted project is a draft (projectStatus === 0) sitting on step 1. Right after
+  // restart, project_current_step can still hold the old (execute-step) value for a beat — the
+  // restart navigate triggers a project re-fetch that may read backend state before it settles,
+  // overwriting our optimistic project_current_step: 1. That would make isStepInvalid true and wedge
+  // the step-1 CTA disabled until a manual reload. A draft project on an early step is never
+  // "already past", so exclude projectStatus === 0 here (mirrors the isProjectStatusOne guard above).
+  const isProjectStatusDraft = newMigrationData?.legacy_cms?.projectStatus === 0;
   const isStepInvalid =
     params?.stepId &&
     params?.stepId <= '2' &&
-    newMigrationData?.project_current_step?.toString() !== params?.stepId && 
-    parseInt(params?.stepId) < newMigrationData?.project_current_step;
+    newMigrationData?.project_current_step?.toString() !== params?.stepId &&
+    parseInt(params?.stepId) < newMigrationData?.project_current_step &&
+    !isProjectStatusDraft;
 
   // Migration is actively running: it has been started (locally or in redux) but not yet completed.
   // While in progress the CTA must be disabled; once completed it re-enables as "Restart Migration".

--- a/ui/src/pages/Migration/index.tsx
+++ b/ui/src/pages/Migration/index.tsx
@@ -58,7 +58,7 @@ import HorizontalStepper from '../../components/Stepper/HorizontalStepper/Horizo
 import LegacyCms from '../../components/LegacyCms';
 import DestinationStackComponent from '../../components/DestinationStack';
 import ContentMapper from '../../components/ContentMapper';
-import EntryMapper from '../../components/ContentMapper/entryMapper';
+import EntryAssetMapper from '../../components/ContentMapper/entryAssetMapper';
 import TestMigration from '../../components/TestMigration';
 import MigrationExecution from '../../components/MigrationExecution';
 import SaveChangesModal from '../../components/Common/SaveChangesModal';
@@ -547,7 +547,7 @@ const Migration = () => {
       ...(isDeltaIteration
         ? [
             {
-              data: <EntryMapper handleStepChange={handleStepChange} />,
+              data: <EntryAssetMapper handleStepChange={handleStepChange} />,
               id: '4',
               title: 'Map Entry'
             }

--- a/ui/src/utilities/constants.ts
+++ b/ui/src/utilities/constants.ts
@@ -209,3 +209,17 @@ export const CONTENT_MAPPER_EMPTY_STATE = {
   NO_CONTENT_TYPES_DESCRIPTION:
     'An error occurred while generating the content mapper. Please go to the Legacy CMS step and validate the file again.'
 }
+
+// Entry Mapper (Map Entry step) empty-state text.
+export const ENTRY_MAPPER_EMPTY_STATE = {
+  NO_ENTRIES_HEADING: 'No entries available for mapping',
+  NO_ENTRIES_DESCRIPTION:
+    'There are no entries available to map for the already-migrated content types. You can still continue.'
+}
+
+// Asset Mapper (Map Entry step → Assets tab) empty-state text.
+export const ASSET_MAPPER_EMPTY_STATE = {
+  NO_ASSETS_HEADING: 'No assets available for mapping',
+  NO_ASSETS_DESCRIPTION:
+    'There are no assets available to map for the already-migrated content. You can still continue.'
+}


### PR DESCRIPTION
## 🔗 Jira Ticket

- [CMG-1000](https://contentstack.atlassian.net/browse/CMG-1000)
- [CMG-1002](https://contentstack.atlassian.net/browse/CMG-1002)
- [CMG-1003](https://contentstack.atlassian.net/browse/CMG-1003)
- [CMG-1004](https://contentstack.atlassian.net/browse/CMG-1004)

---

## 📋 PR Type

- [] ✨ Feature
- [x] 🐛 Bug Fix
- [] 🔥 Hotfix
- [x] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

**Step 4 mapping (Entries + Assets)**
- Reverted **Step 3 (Map Content Fields)** back to content-types only — removed the Entries/Assets toggle and the inline Asset/Entry mappers that had been added there.
- Added **`EntryAssetMapper`** as Step 4's component: holds the Entries/Assets toggle and renders `EntryMapper` or `AssetMapper`.
- Both tabs always render, each with its own empty state — "No entries available for mapping" and "No assets available for mapping" — using the same `step-container` + centered `EmptyState` pattern.
- Added `ASSET_MAPPER_EMPTY_STATE` constant; asset empty state gated on `hasFetched` so it doesn't flash before the first fetch settles.

**Legacy CMS file-format validation**
- Moved the "file format not supported" error from the CMS select step (`LoadSelectCms`) to the file format step (`LoadFileFormat`), where the error actually belongs.
- Format is now validated against the **actual uploaded file extension** (not the pre-seeded `selectedFileFormat`), so editing the file path (e.g. `zip → json`) keeps the label, icon, and Redux in sync.

**Misc**
- `MigrationFlowHeader` + `entryMapper` empty-state text tweaks.

### Why?

- Asset and entry mapping were previously separated; a teammate had merged them into the Content Mapper screen. This restores the separation — Step 3 shows new content types, Step 4 handles asset/entry mapping.
- The file-format error was firing on the wrong step and reading from a stale format value, so a mismatched upload could be masked by the CMS's default format.

---

## 🧩 Affected Areas

- [ ] `api` — Node.js backend
- [x] `ui` — React frontend
- [ ] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

1. Run a **delta migration (iteration 2+)** so the 6-step flow appears.
2. Open **Step 3 (Map Content Fields)** — confirm it shows only new content types, no Entries/Assets toggle.
3. Open **Step 4 (Map Entry)** — confirm the **Entries / Assets** toggle is present.
   - Switch to **Entries** with no mappable entries → "No entries available for mapping".
   - Switch to **Assets** with no mappable assets → "No assets available for mapping".
4. On **Step 1 (Select Legacy CMS)**, upload a file whose format isn't supported by the selected CMS → error shows on the **file format** field (not on CMS select).
5. Edit the file path to a supported format (e.g. `zip → json`) → error clears and the label/icon update.

**Expected result:** Step 3 = content types only; Step 4 = entry/asset mapping with per-tab empty states; file-format errors surface on the file format step and react to the actual uploaded extension.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

-

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `feature/`, `bugfix/`, or `hotfix/` + 5–30 lowercase chars
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added — N/A
- [x] No sensitive credentials or secrets committed
- [x] Existing tests pass locally (`npm test`)
- [ ] New tests written (or not applicable — explain why)
- [ ] `README.md` / docs updated if behaviour changed — N/A
- [x] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

- `AssetMapper` still accepts an optional `onCountChange` prop that `EntryAssetMapper` no longer passes — harmless, left for flexibility. Flag if you'd rather drop it.
- The file-format validation logic moved between two files (`LoadSelectCms` → `LoadFileFormat`); worth confirming there's no remaining path that relies on the old `LoadSelectCms` error.

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) · [Issues](https://github.com/contentstack/migration-v2/issues)
