### PR TITLE
CMG-1007 | Stepper navigation and locale dropdown on restart migration

### DIFF
--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -622,8 +622,8 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
             {/* Entry Mapping Table */}
             <div className="content-types-fields-wrapper">
               <div className="table-wrapper" ref={tableWrapperRef}>
-                <div className={`entry-mapper-container${localeOptions?.length > 1 ? ' has-locale-select' : ''}`}>
-                  {localeOptions?.length > 1 && (
+                <div className={`entry-mapper-container${localeOptions?.length > 0 ? ' has-locale-select' : ''}`}>
+                  {localeOptions?.length > 0 && (
                     <div className="locale-select-inline">
                       <Select
                         className="locale-select"

--- a/ui/src/components/DestinationStack/Actions/LoadLanguageMapper.tsx
+++ b/ui/src/components/DestinationStack/Actions/LoadLanguageMapper.tsx
@@ -48,23 +48,58 @@ const Mapper = ({
   isStackChanged: boolean;
   stack: IDropDown
 }) => {
-  const [selectedMappings, setSelectedMappings] = useState<{ [key: string]: string }>({});
+  const newMigrationData = useSelector((state: RootState) => state?.migration?.newMigrationData);
+  const dispatch = useDispatch();
+  // Seed from the saved localeMapping in Redux so the component doesn't wipe the existing
+  // mapping on mount. Critical for the restart flow — without this the previous run's locale
+  // mapping disappears the moment the user lands on Step 2 again.
+  const [selectedMappings, setSelectedMappings] = useState<{ [key: string]: string }>(
+    () => ({ ...(newMigrationData?.destination_stack?.localeMapping || {}) }),
+  );
+  // If Redux's localeMapping arrives *after* mount (e.g., fetchData dispatches it post-render),
+  // top up selectedMappings with any keys it has that we don't, so the master/additional rows
+  // keep their saved source values. Existing keys in selectedMappings (user-edited or seeded)
+  // are not overwritten.
+  useEffect(() => {
+    const fromRedux = newMigrationData?.destination_stack?.localeMapping || {};
+    setSelectedMappings((prev) => {
+      let next = prev;
+      for (const [k, v] of Object.entries(fromRedux)) {
+        if (v && (!(k in prev) || !prev[k])) {
+          if (next === prev) next = { ...prev };
+          next[k] = v as string;
+        }
+      }
+      return next;
+    });
+  }, [newMigrationData?.destination_stack?.localeMapping]);
   const [existingField, setExistingField] = useState<ExistingFieldType>({});
   const [existingLocale, setexistingLocale] = useState<ExistingFieldType>({});
   const [selectedCsOptions, setselectedCsOption] = useState<string[]>([]);
   const [selectedSourceOption, setselectedSourceOption] = useState<string[]>([]);
   const [csOptions, setcsOptions] = useState(options);
   const [sourceoptions, setsourceoptions] = useState(sourceOptions);
-  const newMigrationData = useSelector((state: RootState) => state?.migration?.newMigrationData);
-  const dispatch = useDispatch();
   const [selectedStack, setSelectedStack] = useState<IDropDown>();
   const [placeholder] = useState<string>('Select language');
+  // Guards the dispatch effect below from wiping a non-empty Redux localeMapping with an
+  // empty selectedMappings on the very first render (which happens when fetchData hasn't
+  // populated localeMapping yet at the moment of mount).
+  const hasDispatchedOnceRef = useRef(false);
 
   useEffect(()=>{
     setSelectedStack(stack);
   },[]);
 
   useEffect(() => {
+    if (
+      !hasDispatchedOnceRef.current &&
+      Object.keys(selectedMappings || {}).length === 0
+    ) {
+      // First render and we have nothing to dispatch — skip so the sync-from-Redux effect
+      // above can seed selectedMappings without our empty value wiping Redux first.
+      return;
+    }
+    hasDispatchedOnceRef.current = true;
     const newMigrationDataObj: INewMigration = {
       ...newMigrationData,
       destination_stack: {
@@ -144,6 +179,16 @@ const Mapper = ({
           updatedExistingField[index] = {
             label: `${locale?.label}`,
             value: `${locale?.label}-master_locale`,
+          };
+        }
+        // Reflect the saved master source locale in the row UI (the master row reads its
+        // source value from existingLocale[label], not from `locale.value`). Without this
+        // the source dropdown looks blank on restart even though Redux has the value.
+        const savedMasterSource = selectedMappings?.[`${locale?.label}-master_locale`];
+        if (savedMasterSource && !updatedExistingLocale?.[locale?.label]) {
+          updatedExistingLocale[locale?.label] = {
+            label: savedMasterSource,
+            value: savedMasterSource,
           };
         }
 
@@ -431,7 +476,10 @@ const Mapper = ({
                 version="v2"
                 hideSelectedOptions={true}
                 isClearable={true}
-                isDisabled={isDisabled}
+                // Existing rows (have a `value` from the prior mapping) stay locked when the
+                // parent says disabled (e.g. restart iteration). Newly-added rows have an empty
+                // value and must remain editable so the user can pick their locales.
+                isDisabled={isDisabled && !!locale?.value}
                 //className="select-container"
                 menuPlacement="auto"
               />
@@ -480,13 +528,16 @@ const Mapper = ({
                 version="v2"
                 hideSelectedOptions={true}
                 isClearable={true}
-                isDisabled={isDisabled}
+                // Existing rows (have a `value` from the prior mapping) stay locked when the
+                // parent says disabled (e.g. restart iteration). Newly-added rows have an empty
+                // value and must remain editable so the user can pick their locales.
+                isDisabled={isDisabled && !!locale?.value}
                 //className="select-container"
                 menuPlacement="auto"
               />
             }
             <div className={'delete-icon'}>
-              {locale?.value !== 'master_locale' && !isDisabled && (
+              {locale?.value !== 'master_locale' && (!isDisabled || !locale?.value) && (
                 <Tooltip content={'Delete'} position="top" showArrow={false}>
                   <Icon
                     icon="Trash"
@@ -575,62 +626,82 @@ const LanguageMapper = ({stack, uid} :{ stack : IDropDown, uid : string}) => {
         setsourceLocales(sourceLocale);
         setoptions(allLocales);
         const keys = Object?.keys(newMigrationData?.destination_stack?.localeMapping || {})?.find( key => key === `${newMigrationData?.destination_stack?.selectedStack?.master_locale}-master_locale`);
-        if((Object?.entries(newMigrationData?.destination_stack?.localeMapping)?.length === 0 || 
-        !keys || 
-        currentStack?.uid !== previousStack?.uid || isStackChanged) &&
-        newMigrationData?.project_current_step <= 2)
-        {
-         setcmsLocaleOptions((prevList: { label: string ; value: string }[]) => {
-          const newLabel = stack?.master_locale ?? '';
-    
-            const isPresent = prevList?.filter(
-              (item: { label: string; value: string }) => (item?.value === 'master_locale')
+        const isRestartIteration = (newMigrationData?.iteration ?? 1) > 1;
+
+        // RESTART (iteration > 1): rebuild the table directly from the saved localeMapping so
+        // each entry becomes exactly one row — the master row keyed `<code>-master_locale`
+        // renders with value='master_locale' (locked); additional rows render with their
+        // source locale value. No master-logic branch and no separate rehydration block, so
+        // the two can't collide and produce phantom duplicates.
+        if (isRestartIteration) {
+          const savedMapping = newMigrationData?.destination_stack?.localeMapping || {};
+          const rebuilt = Object?.entries(savedMapping)?.map(([key, value]) => {
+            const isMasterKey = key?.endsWith('-master_locale');
+            return isMasterKey
+              ? { label: key.replace(/-master_locale$/, ''), value: 'master_locale' }
+              : { label: key, value: String(value) };
+          });
+          // Preserve any pending newly-added empty rows the user is filling out.
+          setcmsLocaleOptions((prevList) => {
+            const pendingNewRows = (prevList ?? []).filter((r) => !r?.value);
+            return [...rebuilt, ...pendingNewRows];
+          });
+        } else {
+          if((Object?.entries(newMigrationData?.destination_stack?.localeMapping)?.length === 0 ||
+          !keys ||
+          currentStack?.uid !== previousStack?.uid || isStackChanged) &&
+          newMigrationData?.project_current_step <= 2)
+          {
+           setcmsLocaleOptions((prevList: { label: string ; value: string }[]) => {
+            const newLabel = stack?.master_locale ?? '';
+
+              const isPresent = prevList?.filter(
+                (item: { label: string; value: string }) => (item?.value === 'master_locale')
+              );
+              if(isPresent?.[0]?.label !== newLabel || currentStack?.uid !== previousStack?.uid || isStackChanged){
+                //setisStackChanged(false);
+                return [
+                  ...prevList?.filter(item => (item?.value !== 'master_locale' && item?.value !== '')) ?? [],
+                  {
+                    label: newLabel,
+                    value: 'master_locale',
+                  }
+                ];
+              }
+              if (isPresent?.length <= 0 ) {
+                return [
+                  ...prevList,
+                  {
+                    label: newLabel,
+                    value: 'master_locale'
+                  }
+                ];
+              }
+
+              return prevList;
+            });}
+          // Re-hydrate the saved locale mapping into the table when the user has progressed past
+          // Step 2 in a normal (non-restart) flow.
+          if (newMigrationData?.project_current_step > 2) {
+            Object?.entries(newMigrationData?.destination_stack?.localeMapping || {})?.forEach(
+              ([key, value]) => {
+                setcmsLocaleOptions((prevList) => {
+                  const labelKey = key?.replace(/-master_locale$/, '');
+                  const exists = prevList?.some((item) => item?.label === labelKey);
+                  if (!exists) {
+                    return [
+                      ...prevList,
+                      {
+                        label: labelKey,
+                        value: String(value)
+                      }
+                    ];
+                  }
+                  return prevList;
+                });
+              }
             );
-            if(isPresent?.[0]?.label !== newLabel || currentStack?.uid !== previousStack?.uid || isStackChanged){
-              //setisStackChanged(false);
-              return [
-                ...prevList?.filter(item => (item?.value !== 'master_locale' && item?.value !== '')) ?? [],
-                {
-                  label: newLabel,
-                  value: 'master_locale',
-                }
-              ];
-            }
-            if (isPresent?.length <= 0 ) {
-              return [
-                ...prevList,
-                {
-                  label: newLabel,
-                  value: 'master_locale'
-                }
-              ];
-            }
-
-            return prevList;
-          });}
-        if (newMigrationData?.project_current_step > 2) {
-          Object?.entries(newMigrationData?.destination_stack?.localeMapping || {})?.forEach(
-            ([key, value]) => {
-              setcmsLocaleOptions((prevList) => {
-                const labelKey = key?.replace(/-master_locale$/, '');
-
-                // Check if the key already exists in the list
-                const exists = prevList?.some((item) => item?.label === labelKey);
-
-                if (!exists) {
-                  return [
-                    ...prevList,
-                    {
-                      label: labelKey,
-                      value: String(value)
-                    }
-                  ];
-                }
-
-                return prevList; // Return the same list if key exists
-              });
-            }
-          );
+          }
         }
         setisLoading(false);
       } catch (error) {
@@ -685,7 +756,7 @@ const LanguageMapper = ({stack, uid} :{ stack : IDropDown, uid : string}) => {
                 cmsLocaleOptions={cmsLocaleOptions}
                 handleLangugeDelete={handleDeleteLocale}
                 sourceOptions={sourceLocales}
-                isDisabled={newMigrationData?.project_current_step > 2}
+                isDisabled={newMigrationData?.project_current_step > 2 || (newMigrationData?.iteration ?? 1) > 1}
                 isStackChanged={isStackChanged}
                 stack={stack ?? DEFAULT_DROPDOWN}
               />
@@ -699,13 +770,24 @@ const LanguageMapper = ({stack, uid} :{ stack : IDropDown, uid : string}) => {
             icon="AddPlus"
             onClick={addRowComp}
             size="small"
-            disabled={
-              Object.keys(newMigrationData?.destination_stack?.localeMapping || {})?.length ===
-                newMigrationData?.destination_stack?.sourceLocale?.length ||
-              cmsLocaleOptions?.length ===
-                newMigrationData?.destination_stack?.sourceLocale?.length ||
-              newMigrationData?.project_current_step > 2
-            }
+            disabled={(() => {
+              const isRestartIteration = (newMigrationData?.iteration ?? 1) > 1;
+              // Non-restart: lock Add Language past Step 2, and prevent adding more rows than
+              // there are source locales (1:1 mapping is required for first-time migration).
+              if (!isRestartIteration) {
+                return (
+                  Object.keys(newMigrationData?.destination_stack?.localeMapping || {})?.length ===
+                    newMigrationData?.destination_stack?.sourceLocale?.length ||
+                  cmsLocaleOptions?.length ===
+                    newMigrationData?.destination_stack?.sourceLocale?.length ||
+                  newMigrationData?.project_current_step > 2
+                );
+              }
+              // Restart iteration: button must remain available so users can add a new
+              // destination locale before the delta run. Only block if there's already an
+              // empty in-progress row waiting to be filled (avoid stacking empties).
+              return cmsLocaleOptions?.some((o) => !o?.value);
+            })()}
           >
             Add Language
           </Button>

--- a/ui/src/components/DestinationStack/Actions/LoadStacks.tsx
+++ b/ui/src/components/DestinationStack/Actions/LoadStacks.tsx
@@ -346,7 +346,7 @@ const LoadStacks = (props: LoadFileFormatProps) => {
               placeholder={placeholder}
               isClearable={allStack?.length > 0 && !emptyStackValue}
               // hideSelectedOptions={true}
-              isDisabled={newMigrationData?.project_current_step > 2}
+              isDisabled={newMigrationData?.project_current_step > 2 || (newMigrationData?.iteration ?? 1) > 1}
               error={isLoading ? false : !!isError}
               width="600px"
               hasAddOption={true}

--- a/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
+++ b/ui/src/components/LegacyCms/Actions/LoadUploadFile.tsx
@@ -246,6 +246,13 @@ const LoadUploadFile = ( props: LoadUploadFileProps ) =>
   );
 
   const newMigrationDataRef = useRef( newMigrationData );
+  // Keep the ref in sync with Redux so dispatches built from `ref.current` don't clobber
+  // recent state (e.g. a fresh restart resets `iteration` and `isValidated`, but the ref
+  // would otherwise still hold the pre-restart snapshot and overwrite those on next dispatch).
+  useEffect( () =>
+  {
+    newMigrationDataRef.current = newMigrationData;
+  }, [ newMigrationData ] );
   const dispatch = useDispatch();
   const [ isLoading, setIsLoading ] = useState<boolean>( false );
   const [ isValidated, setIsValidated ] = useState<boolean>( newMigrationDataRef?.current?.legacy_cms?.uploadedFile?.isValidated );

--- a/ui/src/pages/Migration/index.tsx
+++ b/ui/src/pages/Migration/index.tsx
@@ -116,6 +116,11 @@ const Migration = () => {
 
   const saveRef = useRef<ContentTypeSaveHandles>(null);
   const newMigrationDataRef = useRef(newMigrationData);
+  // Keep the ref in sync with Redux so dispatches built from `ref.current` don't carry
+  // stale snapshots (e.g. pre-restart state) into later updates.
+  useEffect(() => {
+    newMigrationDataRef.current = newMigrationData;
+  }, [newMigrationData]);
 
   useEffect(() => {
     fetchData();
@@ -652,17 +657,23 @@ const Migration = () => {
 
       if (res?.status === 200) {
         setIsLoading(false);
-        // Check if stack is already selected
-        if (newMigrationData?.destination_stack?.selectedStack?.value) {
+        // On a restart (iteration > 1) we must NOT skip Step 2 — that's where the user
+        // can review/adjust locale mapping (e.g. add a new locale before a delta run).
+        const isRestart = (newMigrationData?.iteration ?? 1) > 1;
+        // Otherwise, if a stack is already chosen we can jump straight to Step 3.
+        if (!isRestart && newMigrationData?.destination_stack?.selectedStack?.value) {
           const url = `/projects/${projectId}/migration/steps/3`;
-
+          // Bump current_step a second time so backend lands on Step 3 (Content Mapping)
+          // — we're skipping Step 2 because the destination stack is already configured.
           await updateCurrentStepData(selectedOrganisation?.value, projectId);
 
           handleStepChange(2);
           navigate(url, { replace: true });
         } else {
+          // Going to Step 2 — backend was already advanced once above (Step 1 → 2). Do NOT
+          // bump again, otherwise current_step ends up at 3 and the `project_current_step > 2`
+          // gate on Step 2's stack/locale/Add-Language buttons would disable everything.
           const url = `/projects/${projectId}/migration/steps/2`;
-          await updateCurrentStepData(selectedOrganisation?.value, projectId);
 
           handleStepChange(1);
           navigate(url, { replace: true });
@@ -917,6 +928,10 @@ const Migration = () => {
   };
 
   const handleRestartMigration = async () => {
+    // Reset the locally-tracked "Start Migration in flight" flag from any prior run, otherwise
+    // MigrationFlowHeader receives finalExecutionStarted=true and disables Save and Continue
+    // on Step 1 (via isMigrationInProgress) until the user refreshes.
+    setDisableMigration(false);
     const newMigrationDataObj: INewMigration = {
       ...newMigrationData,
       legacy_cms: {


### PR DESCRIPTION
## 🔗 Jira Ticket

[CMG-1007](https://contentstack.atlassian.net/browse/CMG-1007)

---

## 📋 PR Type

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

- Restart now lands on Step 2 (Configure Destination Stack) instead of skipping to Step 3, so users can review/update locale mapping before a delta run.
- Save and Continue on Step 1 enables immediately after file validation — no refresh needed.
- Step 2 on restart: stack dropdown locked, existing locale rows shown in disabled state, Add Language stays enabled, and the master row's source locale is pre-filled.
- Map Entry locale dropdown is now visible whenever at least one locale is mapped (previously hidden when only one).

### Why?

Several state-management bugs in the restart flow blocked users at multiple steps and forced page refreshes to recover. Fixing the stepper progression and ensuring the locale mapping persists across restarts.

---

## 🧩 Affected Areas

- [ ] `api` — Node.js backend
- [x] `ui` — React frontend
- [ ] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

1. On a previously-migrated project, click **Restart Migration** from Step 6.
2. On Step 1, validate the file and confirm **Save and Continue** enables without a page refresh.
3. Click Save and Continue — you should land on **Step 2 (Configure Destination Stack)**, not Step 3.
4. Confirm: stack dropdown is locked, existing locale mapping rows are visible & disabled (master row's source locale pre-filled), and **Add Language** is enabled. Save and Continue should proceed cleanly.
5. On Step 4 (Map Entry), confirm the locale dropdown appears even when only one locale is mapped.

**Expected result:** Restart flow walks through Steps 1 → 2 → 3 without forced refreshes, with all prior state preserved correctly and locale-aware controls behaving consistently.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

- Builds on the locale-based delta migration PR ([CMG-998](https://contentstack.atlassian.net/browse/CMG-998)).

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `bugfix/cmg-1007-stepper-and-locale`
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added (n/a)
- [x] No sensitive credentials or secrets committed
- [x] Existing tests pass locally (`npm test`)
- [ ] New tests written (or not applicable — UI behavior fixes, covered by manual testing)
- [ ] `README.md` / docs updated if behaviour changed (n/a)
- [x] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

- The Mapper component's `selectedMappings` is now seeded from Redux's `localeMapping` and kept in sync via a separate effect, so the saved mapping survives Step 2 remount on restart.
- A `hasDispatchedOnceRef` guard skips the very first empty-state dispatch from Mapper so it can't wipe Redux's `localeMapping` before the sync effect populates `selectedMappings`.
- Per-row override (`isDisabled && !!locale?.value`) on Mapper's Selects keeps newly-added empty rows editable on restart while existing rows stay locked.
- The double `updateCurrentStepData` call in `handleOnClickLegacyCms` was reduced to one for the Step 1 → Step 2 path so backend's `current_step` doesn't overshoot to 3 and disable Step 2 controls.

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) · [Issues](https://github.com/contentstack/migration-v2/issues)