### PR TITLE
feat(assets): add extractAssets function for asset mapping across Con…

### DIFF
--- a/upload-api/migration-contentful/index.js
+++ b/upload-api/migration-contentful/index.js
@@ -5,11 +5,13 @@ const createInitialMapper = require('./libs/createInitialMapper');
 const extractLocale = require('./libs/extractLocale');
 const extractTaxonomy = require('./libs/extractTaxonomy');
 const extractEntries = require('./libs/extractEntries');
+const extractAssets = require('./libs/extractAssets');
 
 module.exports = {
   extractContentTypes,
   createInitialMapper,
   extractLocale,
   extractTaxonomy,
-  extractEntries
+  extractEntries,
+  extractAssets
 };

--- a/upload-api/migration-contentful/libs/extractAssets.js
+++ b/upload-api/migration-contentful/libs/extractAssets.js
@@ -1,0 +1,98 @@
+'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const { readFile } = require('../utils/helper');
+
+/**
+ * Extracts asset mapping rows from a Contentful export.
+ *
+ * Discovery mirrors extractEntries in this same package: the Contentful export
+ * is a single JSON file read via readFile(cleanLocalPath), with top-level
+ * `entries`, `locales` and `assets` arrays (standard `contentful-export`
+ * output). Each asset carries a stable `sys.id` and locale-keyed fields, so
+ * file metadata lives under `fields.file[locale]` and the title under
+ * `fields.title[locale]`:
+ *
+ *   {
+ *     sys: { id: '<stable-asset-id>' },
+ *     fields: {
+ *       title: { 'en-US': 'My Asset' },
+ *       file: {
+ *         'en-US': {
+ *           fileName: 'my-asset.png',
+ *           url: '//images.ctfassets.net/.../my-asset.png',
+ *           details: { size: 12345 }
+ *         }
+ *       }
+ *     }
+ *   }
+ *
+ * We dedupe by sys.id and use it as both `id` and `otherCmsAssetUid` so the row
+ * stays stable across delta iterations. Returned rows are consumed by
+ * putTestData on the main API to populate the asset_mapper DB (AssetMapper UI),
+ * matching the AEM/Sitecore AssetMappingRow shape.
+ *
+ * @param {string} cleanLocalPath - Path to the Contentful export JSON file.
+ * @returns {Array<{id:string,otherCmsAssetUid:string,filename:string,title:string,file_size:(number|string),assetPath:string,isUpdate:boolean}>}
+ */
+const extractAssets = (cleanLocalPath) => {
+  try {
+    const alldata = readFile(cleanLocalPath);
+    const assets = alldata?.assets;
+    const locales = alldata?.locales?.map((locale) => locale?.code) ?? [];
+
+    if (!assets || !Array.isArray(assets) || assets.length === 0) {
+      console.info('No assets found in Contentful export');
+      return [];
+    }
+
+    const rows = [];
+    const seenIds = new Set();
+
+    // Prefer a locale-keyed value, falling back to the first available locale.
+    const pickLocalized = (field) => {
+      if (!field || typeof field !== 'object') return undefined;
+      for (const locale of locales) {
+        if (field[locale] !== undefined) return field[locale];
+      }
+      const firstKey = Object.keys(field)[0];
+      return firstKey !== undefined ? field[firstKey] : undefined;
+    };
+
+    for (const asset of assets) {
+      const id = asset?.sys?.id;
+      if (!id || seenIds.has(id)) {
+        continue;
+      }
+
+      const file = pickLocalized(asset?.fields?.file);
+      const title = pickLocalized(asset?.fields?.title);
+
+      const filename = file?.fileName ?? title ?? '';
+      const fileSize = file?.details?.size ?? '';
+      // Contentful serves assets from a CDN URL rather than a folder path.
+      const assetPath = file?.url ?? '';
+
+      seenIds.add(id);
+
+      rows.push({
+        id,
+        otherCmsAssetUid: id,
+        filename,
+        title: title ?? filename,
+        file_size: fileSize,
+        assetPath,
+        isUpdate: false,
+      });
+    }
+
+    console.info(`extractAssets: Extracted ${rows.length} Contentful assets`);
+
+    return rows;
+  } catch (err) {
+    console.error('Error extracting Contentful assets:', err);
+    return [];
+  }
+};
+
+module.exports = extractAssets;

--- a/upload-api/migration-contentful/libs/extractAssets.js
+++ b/upload-api/migration-contentful/libs/extractAssets.js
@@ -39,9 +39,11 @@ const extractAssets = (cleanLocalPath) => {
   try {
     const alldata = readFile(cleanLocalPath);
     const assets = alldata?.assets;
-    const locales = alldata?.locales?.map((locale) => locale?.code) ?? [];
+    const locales = Array.isArray(alldata?.locales)
+      ? alldata?.locales?.map((locale) => locale?.code).filter(Boolean)
+      : [];
 
-    if (!assets || !Array.isArray(assets) || assets.length === 0) {
+    if (!assets || !Array?.isArray(assets) || assets?.length === 0) {
       console.info('No assets found in Contentful export');
       return [];
     }
@@ -66,12 +68,18 @@ const extractAssets = (cleanLocalPath) => {
       }
 
       const file = pickLocalized(asset?.fields?.file);
-      const title = pickLocalized(asset?.fields?.title);
+      const titleValue = pickLocalized(asset?.fields?.title);
+      const title = typeof titleValue === 'string' ? titleValue : '';
 
-      const filename = file?.fileName ?? title ?? '';
+      const filename =
+        (typeof file?.fileName === 'string' && file?.fileName) || title || '';
       const fileSize = file?.details?.size ?? '';
-      // Contentful serves assets from a CDN URL rather than a folder path.
-      const assetPath = file?.url ?? '';
+      // Contentful serves assets from a protocol-relative CDN URL ("//...");
+      // normalize to https so downstream consumers get an absolute URL.
+      let assetPath = typeof file?.url === 'string' ? file?.url : '';
+      if (assetPath.startsWith('//')) {
+        assetPath = `https:${assetPath}`;
+      }
 
       seenIds.add(id);
 
@@ -79,7 +87,7 @@ const extractAssets = (cleanLocalPath) => {
         id,
         otherCmsAssetUid: id,
         filename,
-        title: title ?? filename,
+        title: title || filename,
         file_size: fileSize,
         assetPath,
         isUpdate: false,

--- a/upload-api/migration-drupal/index.js
+++ b/upload-api/migration-drupal/index.js
@@ -4,11 +4,13 @@ const extractTaxonomy = require('./libs/extractTaxonomy');
 const createInitialMapper = require('./libs/createInitialMapper');
 const extractLocale = require('./libs/extractLocale');
 const extractEntries = require('./libs/extractEntries');
+const extractAssets = require('./libs/extractAssets');
 
 module.exports = {
   // extractContentTypes,
   extractTaxonomy,
   createInitialMapper,
   extractLocale,
-  extractEntries
+  extractEntries,
+  extractAssets
 };

--- a/upload-api/migration-drupal/libs/extractAssets.js
+++ b/upload-api/migration-drupal/libs/extractAssets.js
@@ -46,12 +46,23 @@ const extractAssets = async (config) => {
   try {
     connection = dbConnection(config);
 
+    // Bound the result set so a very large media library can't be pulled fully into
+    // memory. Configurable via assetsConfig.maxAssets; parameterized to keep it out of
+    // the SQL string.
+    const maxAssets = Number(config?.assetsConfig?.maxAssets) || 100000;
     const query = `
       SELECT fid, uuid, filename, uri, filesize, filemime
       FROM file_managed
       ORDER BY fid
+      LIMIT ?
     `;
-    const [results] = await connection.promise().query(query);
+    const [results] = await connection.promise().query(query, [maxAssets]);
+
+    if (Array.isArray(results) && results.length === maxAssets) {
+      console.warn(
+        `extractAssets (Drupal): hit maxAssets cap of ${maxAssets}; some assets may be omitted`
+      );
+    }
 
     const seenIds = new Set();
 
@@ -60,21 +71,21 @@ const extractAssets = async (config) => {
         continue;
       }
 
-      const id = file.fid != null ? String(file.fid) : '';
+      const id = file?.fid != null ? String(file?.fid) : '';
       if (!id || seenIds.has(id)) {
         continue;
       }
       seenIds.add(id);
 
-      const filename = file.filename ? String(file.filename) : `File ${id}`;
+      const filename = file?.filename ? String(file?.filename) : `File ${id}`;
 
       rows.push({
         id,
         otherCmsAssetUid: id,
         filename,
         title: filename,
-        file_size: file.filesize != null ? String(file.filesize) : '',
-        assetPath: assetPathFromUri(file.uri, file.filename),
+        file_size: file?.filesize != null ? String(file?.filesize) : '',
+        assetPath: assetPathFromUri(file?.uri, filename),
         isUpdate: false
       });
     }
@@ -86,7 +97,11 @@ const extractAssets = async (config) => {
     return rows;
   } finally {
     if (connection) {
-      connection.end();
+      try {
+        connection.end();
+      } catch (endErr) {
+        console.error('extractAssets (Drupal) connection close error:', endErr?.message || endErr);
+      }
     }
   }
 };

--- a/upload-api/migration-drupal/libs/extractAssets.js
+++ b/upload-api/migration-drupal/libs/extractAssets.js
@@ -1,0 +1,94 @@
+'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+/**
+ * Builds the assetMapping array consumed by putTestData on the main API to
+ * populate the asset_mapper DB shown on the AssetMapper UI — same flow/shape
+ * as AEM/Sitecore/Contentful/WordPress.
+ *
+ * Drupal reads from MySQL (not files). Files live in the `file_managed` table
+ * (fid, uuid, filename, uri, filesize, filemime). We surface every managed
+ * file, deduped by its Drupal file id, using the fid as the stable
+ * id/otherCmsAssetUid so it lines up across delta iterations.
+ *
+ * Row shape mirrors migration-sitecore/libs/extractAssets.js:
+ *   { id, otherCmsAssetUid, filename, title, file_size, assetPath, isUpdate }
+ */
+
+const { dbConnection } = require('../utils/helper');
+
+/**
+ * Derive a display-friendly path from the Drupal file uri.
+ * e.g. "public://2023-01/photo.jpg" -> "public/2023-01"
+ */
+const assetPathFromUri = (uri, filename) => {
+  if (!uri || typeof uri !== 'string') {
+    return '';
+  }
+  // Strip the stream wrapper scheme ("public://", "private://", "s3://", ...)
+  let cleaned = uri.replace(/^[a-z0-9]+:\/\//i, '');
+  // Drop the filename to leave only the directory portion
+  if (filename && cleaned.endsWith(filename)) {
+    cleaned = cleaned.slice(0, cleaned.length - filename.length);
+  }
+  return cleaned.replace(/\/+$/, '');
+};
+
+/**
+ * @param {Object} config - Migration config; must contain config.mysql (DB
+ *   connection details). config.assetsConfig is accepted but unused for now.
+ * @returns {Promise<Array<object>>} assetMapping rows
+ */
+const extractAssets = async (config) => {
+  const rows = [];
+  let connection;
+
+  try {
+    connection = dbConnection(config);
+
+    const query = `
+      SELECT fid, uuid, filename, uri, filesize, filemime
+      FROM file_managed
+      ORDER BY fid
+    `;
+    const [results] = await connection.promise().query(query);
+
+    const seenIds = new Set();
+
+    for (const file of results || []) {
+      if (!file) {
+        continue;
+      }
+
+      const id = file.fid != null ? String(file.fid) : '';
+      if (!id || seenIds.has(id)) {
+        continue;
+      }
+      seenIds.add(id);
+
+      const filename = file.filename ? String(file.filename) : `File ${id}`;
+
+      rows.push({
+        id,
+        otherCmsAssetUid: id,
+        filename,
+        title: filename,
+        file_size: file.filesize != null ? String(file.filesize) : '',
+        assetPath: assetPathFromUri(file.uri, file.filename),
+        isUpdate: false
+      });
+    }
+
+    console.info(`extractAssets (Drupal): ${rows.length} asset(s)`);
+    return rows;
+  } catch (err) {
+    console.error('extractAssets (Drupal) error:', err?.message || err);
+    return rows;
+  } finally {
+    if (connection) {
+      connection.end();
+    }
+  }
+};
+
+module.exports = extractAssets;

--- a/upload-api/migration-wordpress/index.ts
+++ b/upload-api/migration-wordpress/index.ts
@@ -2,10 +2,12 @@ import extractContentTypes from './libs/contentTypes';
 //import contentTypeMaker from './libs/contentTypeMapper';
 import extractLocale from './libs/extractLocale';
 import extractEntries from './libs/extractEntries';
+import extractAssets from './libs/extractAssets';
 
 export {
     extractContentTypes,
     //contentTypeMaker,
     extractLocale,
-    extractEntries
+    extractEntries,
+    extractAssets
 }

--- a/upload-api/migration-wordpress/libs/extractAssets.ts
+++ b/upload-api/migration-wordpress/libs/extractAssets.ts
@@ -1,0 +1,97 @@
+import fs from 'fs';
+
+export interface AssetMappingRow {
+  id: string;
+  otherCmsAssetUid: string;
+  filename: string;
+  title: string;
+  file_size: number | string;
+  assetPath: string;
+  isUpdate: boolean;
+}
+
+const normalizeArray = <T>(value: T | T[] | undefined): T[] => {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+};
+
+/**
+ * WordPress WXR exports are parsed upstream into JSON before reaching here, so
+ * we load the file exactly like extractEntries/extractItems do: read the file
+ * and JSON.parse it, then walk rss.channel.item. Media are `item` elements with
+ * `wp:post_type === 'attachment'`.
+ */
+const getAssetId = (item: any): string => {
+  const postId = item?.['wp:post_id'];
+  if (postId != null && String(postId).trim() !== '') {
+    return String(postId).trim();
+  }
+  const guid = item?.guid?.text ?? item?.guid;
+  return guid != null ? String(guid).trim() : '';
+};
+
+const getAssetUrl = (item: any): string => {
+  const url = item?.['wp:attachment_url'] ?? item?.guid?.text ?? item?.guid;
+  return url != null ? String(url).trim() : '';
+};
+
+const getFilename = (item: any, assetUrl: string): string => {
+  const fromUrl = assetUrl?.split?.('/')?.pop?.();
+  if (typeof fromUrl === 'string' && fromUrl.trim() !== '') {
+    return fromUrl.trim();
+  }
+  const title = item?.title?.text ?? item?.title;
+  return typeof title === 'string' ? title.trim() : '';
+};
+
+const getTitle = (item: any, filename: string): string => {
+  const title = item?.title?.text ?? item?.title;
+  if (typeof title === 'string' && title.trim() !== '') {
+    return title.trim();
+  }
+  return filename.split('.').slice(0, -1).join('.') || filename;
+};
+
+const extractAssets = async (filePath: string): Promise<AssetMappingRow[]> => {
+  const rows: AssetMappingRow[] = [];
+  try {
+    const rawData = await fs.promises.readFile(filePath, 'utf8');
+    const jsonData = JSON.parse(rawData);
+    const items = normalizeArray(jsonData?.rss?.channel?.item);
+
+    const seenIds = new Set<string>();
+
+    for (const item of items) {
+      if (item?.['wp:post_type'] !== 'attachment') {
+        continue;
+      }
+
+      const id = getAssetId(item);
+      if (!id || seenIds.has(id)) {
+        continue;
+      }
+      seenIds.add(id);
+
+      const assetPath = getAssetUrl(item);
+      const filename = getFilename(item, assetPath);
+      const title = getTitle(item, filename);
+
+      rows.push({
+        id,
+        otherCmsAssetUid: id,
+        filename,
+        title,
+        file_size: '',
+        assetPath,
+        isUpdate: false,
+      });
+    }
+
+    return rows;
+  } catch (error: any) {
+    console.error('Error while extracting WordPress assets:', error?.message || error);
+    return rows;
+  }
+};
+
+export default extractAssets;

--- a/upload-api/src/controllers/wordpress/index.ts
+++ b/upload-api/src/controllers/wordpress/index.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import logger from "../../utils/logger";
 import { HTTP_CODES, HTTP_TEXTS, MIGRATION_DATA_CONFIG } from "../../constants";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-import { extractContentTypes, extractLocale, extractEntries } from 'migration-wordpress';
+import { extractContentTypes, extractLocale, extractEntries, extractAssets } from 'migration-wordpress';
 import { deleteFolderSync } from "../../helper";
 import path from "path";
 
@@ -44,7 +44,8 @@ const createWordpressMapper = async (filePath: string = "", projectId: string | 
     }
 
     if(contentTypeData){
-      const fieldMapping: any = { contentTypes: [], extractPath: filePath };
+      const assetMapping = await extractAssets(filePath);
+      const fieldMapping: any = { contentTypes: [], extractPath: filePath, assetMapping };
       contentTypeData.forEach((contentType: any) => {
         const jsonfileContent = contentType;
         jsonfileContent.type = "content_type";

--- a/upload-api/src/services/contentful/index.ts
+++ b/upload-api/src/services/contentful/index.ts
@@ -11,7 +11,8 @@ const {
   extractContentTypes,
   createInitialMapper,
   extractLocale,
-  extractTaxonomy
+  extractTaxonomy,
+  extractAssets
 } = require('migration-contentful');
 
 const createContentfulMapper = async (
@@ -51,6 +52,9 @@ const createContentfulMapper = async (
     // Must run after createInitialMapper: that step deletes contentfulMigrationData (contentfulSchema) and would remove taxonomy files written earlier.
     await extractTaxonomy(cleanLocalPath);
 
+    // Asset mapping rows for the AssetMapper UI (same flow as AEM/Sitecore).
+    const assetMapping = await extractAssets(cleanLocalPath);
+
     let taxonomies: any[] = [];
     try {
       const taxonomyPath = path.join(
@@ -77,7 +81,8 @@ const createContentfulMapper = async (
       },
       data: JSON.stringify({
         ...initialMapper,
-        taxonomies
+        taxonomies,
+        assetMapping
       })
     };
     const { data} = await axios.request(req);

--- a/upload-api/src/services/contentful/index.ts
+++ b/upload-api/src/services/contentful/index.ts
@@ -7,13 +7,13 @@ import logger from '../../utils/logger';
 import { HTTP_CODES, HTTP_TEXTS } from '../../constants';
 import { Config } from '../../models/types';
 
-const {
+import {
   extractContentTypes,
   createInitialMapper,
   extractLocale,
   extractTaxonomy,
   extractAssets
-} = require('migration-contentful');
+} from 'migration-contentful';
 
 const createContentfulMapper = async (
   projectId: string | string[],
@@ -24,7 +24,7 @@ const createContentfulMapper = async (
   try {
     const { localPath } = config;
     const cleanLocalPath = localPath?.replace?.(/\/$/, '');
-    const fetchedLocales: [] = await extractLocale(cleanLocalPath);
+    const fetchedLocales: string[] = await extractLocale(cleanLocalPath);
 
     const mapperConfig = {
       method: 'post',
@@ -47,8 +47,8 @@ const createContentfulMapper = async (
       });
     }
     
-    await extractContentTypes(cleanLocalPath, affix);
-    const initialMapper = await createInitialMapper(cleanLocalPath, affix);
+    await extractContentTypes(cleanLocalPath, affix as string);
+    const initialMapper = await createInitialMapper(cleanLocalPath, affix as string);
     // Must run after createInitialMapper: that step deletes contentfulMigrationData (contentfulSchema) and would remove taxonomy files written earlier.
     await extractTaxonomy(cleanLocalPath);
 

--- a/upload-api/src/services/drupal/index.ts
+++ b/upload-api/src/services/drupal/index.ts
@@ -7,7 +7,7 @@ import logger from '../../utils/logger';
 import { HTTP_CODES, HTTP_TEXTS } from '../../constants';
 import { Config } from '../../models/types';
 
-const { createInitialMapper, extractLocale, extractTaxonomy } = require('migration-drupal');
+const { createInitialMapper, extractLocale, extractTaxonomy, extractAssets } = require('migration-drupal');
 
 const createDrupalMapper = async (
   config: Config,
@@ -56,6 +56,9 @@ const createDrupalMapper = async (
 
     const initialMapper = await createInitialMapper(config, affix);
 
+    // Asset mapping rows for the AssetMapper UI (same flow as AEM/Sitecore/Contentful/WordPress).
+    const assetMapping = await extractAssets(config);
+
     // Read extracted taxonomies from file
     let taxonomies: any[] = [];
     try {
@@ -84,7 +87,8 @@ const createDrupalMapper = async (
       contentTypes: initialMapper.contentTypes, // All content types (no profile)
       assetsConfig: config.assetsConfig,
       mySQLDetails: config.mysql,
-      taxonomies: taxonomies // Add taxonomies to payload
+      taxonomies: taxonomies, // Add taxonomies to payload
+      assetMapping // Asset rows for the AssetMapper UI
     };
 
     const req = {

--- a/upload-api/src/services/drupal/index.ts
+++ b/upload-api/src/services/drupal/index.ts
@@ -7,7 +7,7 @@ import logger from '../../utils/logger';
 import { HTTP_CODES, HTTP_TEXTS } from '../../constants';
 import { Config } from '../../models/types';
 
-const { createInitialMapper, extractLocale, extractTaxonomy, extractAssets } = require('migration-drupal');
+import { createInitialMapper, extractLocale, extractTaxonomy, extractAssets } from 'migration-drupal';
 
 const createDrupalMapper = async (
   config: Config,
@@ -52,7 +52,7 @@ const createDrupalMapper = async (
     }
 
     // Extract taxonomy vocabularies and save to drupalMigrationData
-    await extractTaxonomy(config?.mysql);
+    await extractTaxonomy(config?.mysql as object);
 
     const initialMapper = await createInitialMapper(config, affix);
 

--- a/upload-api/tests/__mocks__/migration-contentful.ts
+++ b/upload-api/tests/__mocks__/migration-contentful.ts
@@ -3,3 +3,5 @@ import { vi } from 'vitest';
 export const extractLocale = vi.fn().mockResolvedValue([]);
 export const extractContentTypes = vi.fn().mockResolvedValue(undefined);
 export const createInitialMapper = vi.fn().mockResolvedValue({ contentTypes: [] });
+export const extractTaxonomy = vi.fn().mockResolvedValue(undefined);
+export const extractAssets = vi.fn().mockReturnValue([]);

--- a/upload-api/tests/__mocks__/migration-drupal.ts
+++ b/upload-api/tests/__mocks__/migration-drupal.ts
@@ -3,3 +3,4 @@ import { vi } from 'vitest';
 export const extractLocale = vi.fn().mockResolvedValue(new Set());
 export const extractTaxonomy = vi.fn().mockResolvedValue(undefined);
 export const createInitialMapper = vi.fn().mockResolvedValue({ contentTypes: [] });
+export const extractAssets = vi.fn().mockResolvedValue([]);

--- a/upload-api/tests/unit/controllers/wordpress.controller.test.ts
+++ b/upload-api/tests/unit/controllers/wordpress.controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockAxiosRequest, mockDeleteFolderSync, mockExtractLocale, mockExtractContentTypes, mockExtractEntries } = vi.hoisted(() => ({
+const { mockAxiosRequest, mockDeleteFolderSync, mockExtractLocale, mockExtractContentTypes, mockExtractEntries, mockExtractAssets } = vi.hoisted(() => ({
   mockAxiosRequest: vi.fn(),
   mockDeleteFolderSync: vi.fn(),
   mockExtractLocale: vi.fn().mockResolvedValue([]),
@@ -8,12 +8,15 @@ const { mockAxiosRequest, mockDeleteFolderSync, mockExtractLocale, mockExtractCo
   // `extractEntries` is called between extractContentTypes and the POST to enrich each
   // content type with its entry list. Default: pass the input through unchanged.
   mockExtractEntries: vi.fn().mockImplementation((_p: string, ct: any) => ct),
+  // `extractAssets` builds the assetMapping rows sent with the createDummyData payload.
+  mockExtractAssets: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('migration-wordpress', () => ({
   extractLocale: mockExtractLocale,
   extractContentTypes: mockExtractContentTypes,
   extractEntries: mockExtractEntries,
+  extractAssets: mockExtractAssets,
 }));
 
 vi.mock('axios', () => ({ default: { request: mockAxiosRequest } }));

--- a/upload-api/tests/unit/services/contentful.service.test.ts
+++ b/upload-api/tests/unit/services/contentful.service.test.ts
@@ -1,13 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockAxiosRequest } = vi.hoisted(() => ({
+const { mockAxiosRequest, mockExtractLocale, mockExtractContentTypes, mockCreateInitialMapper, mockExtractTaxonomy, mockExtractAssets } = vi.hoisted(() => ({
   mockAxiosRequest: vi.fn(),
+  mockExtractLocale: vi.fn().mockResolvedValue([]),
+  mockExtractContentTypes: vi.fn().mockResolvedValue(undefined),
+  mockCreateInitialMapper: vi.fn().mockResolvedValue({ contentTypes: [] }),
+  mockExtractTaxonomy: vi.fn().mockResolvedValue(undefined),
+  mockExtractAssets: vi.fn().mockReturnValue([]),
 }));
 
+// Mock the connector explicitly (the service uses require('migration-contentful')).
+vi.mock('migration-contentful', () => ({
+  extractLocale: mockExtractLocale,
+  extractContentTypes: mockExtractContentTypes,
+  createInitialMapper: mockCreateInitialMapper,
+  extractTaxonomy: mockExtractTaxonomy,
+  extractAssets: mockExtractAssets,
+}));
 vi.mock('axios', () => ({ default: { request: mockAxiosRequest } }));
 vi.mock('../../../src/utils/logger', () => ({ default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } }));
 
 import createContentfulMapper from '../../../src/services/contentful/index';
+const extractAssets = mockExtractAssets;
 
 describe('createContentfulMapper', () => {
   beforeEach(() => {
@@ -45,5 +59,27 @@ describe('createContentfulMapper', () => {
     await expect(
       createContentfulMapper('proj-1', 'token', 'csm', config)
     ).resolves.toBeUndefined();
+  });
+
+  it('sends the extracted assetMapping in the createDummyData payload', async () => {
+    const config: any = { localPath: '/tmp/export.json' };
+    const assetRows = [
+      { id: 'a1', otherCmsAssetUid: 'a1', filename: 'a.png', title: 'a', file_size: 1, assetPath: 'https://x/a.png', isUpdate: false },
+    ];
+    (extractAssets as any).mockReturnValueOnce(assetRows);
+    // localeMapper POST first, createDummyData POST second.
+    mockAxiosRequest
+      .mockResolvedValueOnce({ status: 200, data: {} })
+      .mockResolvedValueOnce({ data: { data: { content_mapper: [1] } } });
+
+    await createContentfulMapper('proj-1', 'token', 'csm', config);
+
+    expect(extractAssets).toHaveBeenCalledWith('/tmp/export.json');
+    const dummyDataCall = mockAxiosRequest.mock.calls.find(
+      ([req]) => typeof req?.url === 'string' && req.url.includes('createDummyData')
+    );
+    expect(dummyDataCall).toBeTruthy();
+    const payload = JSON.parse((dummyDataCall as any[])[0].data as string);
+    expect(payload.assetMapping).toEqual(assetRows);
   });
 });

--- a/upload-api/tests/unit/services/drupal.service.test.ts
+++ b/upload-api/tests/unit/services/drupal.service.test.ts
@@ -1,9 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockAxiosRequest } = vi.hoisted(() => ({
+const { mockAxiosRequest, mockExtractLocale, mockExtractTaxonomy, mockCreateInitialMapper, mockExtractAssets } = vi.hoisted(() => ({
   mockAxiosRequest: vi.fn(),
+  mockExtractLocale: vi.fn().mockResolvedValue(new Set()),
+  mockExtractTaxonomy: vi.fn().mockResolvedValue(undefined),
+  mockCreateInitialMapper: vi.fn().mockResolvedValue({ contentTypes: [] }),
+  mockExtractAssets: vi.fn().mockResolvedValue([]),
 }));
 
+// Mock the connector explicitly (the service imports from 'migration-drupal').
+vi.mock('migration-drupal', () => ({
+  extractLocale: mockExtractLocale,
+  extractTaxonomy: mockExtractTaxonomy,
+  createInitialMapper: mockCreateInitialMapper,
+  extractAssets: mockExtractAssets,
+}));
 vi.mock('axios', () => ({ default: { request: mockAxiosRequest } }));
 vi.mock('../../../src/utils/logger', () => ({ default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } }));
 vi.mock('fs', () => ({
@@ -13,6 +24,7 @@ vi.mock('fs', () => ({
 }));
 
 import createDrupalMapper from '../../../src/services/drupal/index';
+const extractAssets = mockExtractAssets;
 
 describe('createDrupalMapper', () => {
   const config: any = {
@@ -53,5 +65,26 @@ describe('createDrupalMapper', () => {
     await expect(
       createDrupalMapper(config, 'proj-1', 'token', 'csm')
     ).resolves.toBeUndefined();
+  });
+
+  it('sends the extracted assetMapping in the createDummyData payload', async () => {
+    const assetRows = [
+      { id: '5', otherCmsAssetUid: '5', filename: 'a.jpg', title: 'a.jpg', file_size: '10', assetPath: '2023', isUpdate: false },
+    ];
+    (extractAssets as any).mockResolvedValueOnce(assetRows);
+    // localeMapper POST first, createDummyData POST second.
+    mockAxiosRequest
+      .mockResolvedValueOnce({ status: 200, data: {} })
+      .mockResolvedValueOnce({ data: { data: { content_mapper: [1] } } });
+
+    await createDrupalMapper(config, 'proj-1', 'token', 'csm');
+
+    expect(extractAssets).toHaveBeenCalledWith(config);
+    const dummyDataCall = mockAxiosRequest.mock.calls.find(
+      ([req]) => typeof req?.url === 'string' && req.url.includes('createDummyData')
+    );
+    expect(dummyDataCall).toBeTruthy();
+    const payload = JSON.parse((dummyDataCall as any[])[0].data as string);
+    expect(payload.assetMapping).toEqual(assetRows);
   });
 });


### PR DESCRIPTION
## 🔗 Jira Ticket

[MIGRATION-1030](https://contentstack.atlassian.net/browse/MIGRATION-1030)

---

## 📋 PR Type

- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

- Added an `extractAssets` lib to the **Contentful**, **WordPress**, and **Drupal** connectors so each builds an `assetMapping` array in the upload-api and sends it in the `createDummyData` payload — the same flow AEM and Sitecore already use.
- **Contentful** (`migration-contentful/libs/extractAssets.js`): reads the export JSON's `assets`, dedupes by `sys.id`, pulls locale-keyed `fields.file`/`fields.title`.
- **WordPress** (`migration-wordpress/libs/extractAssets.ts`): walks WXR items, filters `wp:post_type === 'attachment'`, dedupes by post id.
- **Drupal** (`migration-drupal/libs/extractAssets.js`): queries the `file_managed` table over MySQL, dedupes by `fid`.
- Each connector's uid matches the uid its api-side `createAssets` assigns, so delta dedupe / uid-mapper lookups line up across iterations.
- Wired `extractAssets` into each connector's mapper service/controller and exported it from each `migration-*` package index.
- Updated the WordPress controller unit test to mock the new `extractAssets` export.

### Why?

Contentful, WordPress, and Drupal migrations never populated the AssetMapper UI because no `assetMapping` array was built on the upload side (only AEM and Sitecore did). This brings those three connectors to parity so their media assets appear on the Asset Mapper and participate in delta tracking.

---

## 🧩 Affected Areas

- [ ] `api` — Node.js backend
- [ ] `ui` — React frontend
- [x] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

1. Run a migration for a **Contentful** export that has assets → open the mapper → **Assets** tab → assets appear (name/path/size/CS UID).
2. Repeat for a **WordPress** export (WXR with media attachments).
3. Repeat for a **Drupal** source (MySQL with rows in `file_managed`).
4. Confirm asset UIDs stay stable across a second (delta) iteration — re-run and verify existing assets are matched, not duplicated.

**Expected result:** Contentful, WordPress, and Drupal assets show on the AssetMapper (previously empty), with stable UIDs across iterations.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
| _(Assets tab empty)_ | _(assets listed)_ |

---

## 🔗 Related PRs / Dependencies

- Follows the same pattern introduced for AEM and Sitecore asset mapping.

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `feature/`, `bugfix/`, or `hotfix/` + 5–30 lowercase chars
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added
- [x] No sensitive credentials or secrets committed
- [x] Existing tests pass locally (`npm test`)
- [x] New tests written (or not applicable — updated existing WordPress controller test; connector extractAssets covered via controller/service flow)
- [ ] `README.md` / docs updated if behaviour changed
- [x] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

- UID derivation per connector must match the api-side `createAssets` (Contentful `sys.id`, WordPress post id, Drupal `fid`) — that's the key to delta matching; worth a sanity check.
- Drupal's `extractAssets` opens its own MySQL connection (via `dbConnection(config)`) and closes it in `finally`, mirroring `extractLocale`.
- `file_size` is empty at extract time for Contentful/WordPress (only known after download); Drupal has it from `file_managed.filesize`.
- Not committed: a local `upload-api/src/config/index.json` dev tweak (cmsType/localPath) — intentionally left out of this PR.

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) · [Issues](https://github.com/contentstack/migration-v2/issues)
