### PR TITLE
feat(extractEntries, extractItems, schemaMapper): enhance UID generat…

### DIFF
--- a/upload-api/migration-wordpress/constants/index.ts
+++ b/upload-api/migration-wordpress/constants/index.ts
@@ -1,4 +1,4 @@
-{
+export const blocks = {
     "core/paragraph": "text",
     "core/image": "image",
     "core/heading": "heading",
@@ -40,5 +40,10 @@
     "core/post-author": "post_author",
     "core/comments-template": "comments_template",
     "core/comments-count": "comments_count",
-    "core/comment-author-name": "comment_author_name"                                                                                                                                                                                                                        
-}
+    "core/comment-author-name": "comment_author_name"
+}    
+export const EXCLUDED_POST_TYPES = new Set(['attachment', 'wp_global_styles', 'wp_navigation']);
+
+export const ALLOWED_POST_STATUSES = new Set(['publish', 'inherit']);
+
+export const MAX_SUFFIX_LEN = 40;

--- a/upload-api/migration-wordpress/libs/extractEntries.ts
+++ b/upload-api/migration-wordpress/libs/extractEntries.ts
@@ -49,10 +49,7 @@ const getEntryName = (item: any): string => {
   return 'Untitled Entry';
 };
 
-/**
- * All WordPress source entry keys use `posts_${...}` (any content type) so they align with
- * wordpress.service export JSON and CLI uid-mapping.
- */
+
 const getSourceEntryUid = (item: any): string => {
   const postId = item?.['wp:post_id'];
   if (postId != null && String(postId).trim() !== '') {

--- a/upload-api/migration-wordpress/libs/extractEntries.ts
+++ b/upload-api/migration-wordpress/libs/extractEntries.ts
@@ -7,6 +7,8 @@ const contentTypeFolderPath = path.resolve(config?.data, contentTypesConfig?.dir
 
 const EXCLUDED_POST_TYPES = new Set(['attachment', 'wp_global_styles', 'wp_navigation']);
 
+const ALLOWED_POST_STATUSES = new Set(['publish', 'inherit']);
+
 const normalizeArray = <T>(value: T | T[] | undefined): T[] => {
   if (!value) return [];
   return Array.isArray(value) ? value : [value];
@@ -59,12 +61,12 @@ const getSourceEntryUid = (item: any): string => {
 
   const authorId = item?.['wp:author_id'];
   if (authorId != null && String(authorId).trim() !== '') {
-    return idCorrector(`posts_${authorId}`);
+    return idCorrector(`authors_${authorId}`);
   }
 
   const termId = item?.['wp:term_id'];
   if (termId != null && String(termId).trim() !== '') {
-    return idCorrector(`posts_${termId}`);
+    return idCorrector(`terms_${termId}`);
   }
 
   const candidate =
@@ -102,6 +104,8 @@ const extractEntries = async (filePath: string, contentTypeData: any[] = []) => 
     const groupedByType = items?.reduce((acc: Record<string, any[]>, item: any) => {
       const postType = item?.['wp:post_type'] || 'unknown';
       if (EXCLUDED_POST_TYPES.has(postType)) return acc;
+      const postStatus = String(item?.['wp:status'] || '').toLowerCase();
+      if (!ALLOWED_POST_STATUSES.has(postStatus)) return acc;
       if (!acc[postType]) acc[postType] = [];
       acc[postType].push(item);
       return acc;
@@ -112,7 +116,7 @@ const extractEntries = async (filePath: string, contentTypeData: any[] = []) => 
     if (authorData) {
       const authorEntries = normalizeArray(authorData).map((author: any) => ({
         'wp:post_type': 'author',
-        'wp:post_id': author?.['wp:author_id'],
+        'wp:author_id': author?.['wp:author_id'],
         title: author?.['wp:author_display_name'] || author?.['wp:author_login'],
         'wp:author_login': author?.['wp:author_login'],
         'wp:author_email': author?.['wp:author_email'],

--- a/upload-api/migration-wordpress/libs/extractEntries.ts
+++ b/upload-api/migration-wordpress/libs/extractEntries.ts
@@ -131,7 +131,6 @@ const extractEntries = async (filePath: string, contentTypeData: any[] = []) => 
     if (termData) {
       const termEntries = normalizeArray(termData).map((term: any) => ({
         'wp:post_type': 'terms',
-        'wp:post_id': term?.['wp:term_id'],
         title: term?.['wp:term_name'] || term?.['wp:term_slug'],
         'wp:term_id': term?.['wp:term_id'],
         'wp:term_taxonomy': term?.['wp:term_taxonomy'],

--- a/upload-api/migration-wordpress/libs/extractEntries.ts
+++ b/upload-api/migration-wordpress/libs/extractEntries.ts
@@ -1,13 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import config from '../config/index.json';
+import { EXCLUDED_POST_TYPES, ALLOWED_POST_STATUSES } from '../constants/index';
+
 
 const { contentTypes: contentTypesConfig } = config?.modules;
 const contentTypeFolderPath = path.resolve(config?.data, contentTypesConfig?.dirName);
-
-const EXCLUDED_POST_TYPES = new Set(['attachment', 'wp_global_styles', 'wp_navigation']);
-
-const ALLOWED_POST_STATUSES = new Set(['publish', 'inherit']);
 
 const normalizeArray = <T>(value: T | T[] | undefined): T[] => {
   if (!value) return [];

--- a/upload-api/migration-wordpress/libs/extractItems.ts
+++ b/upload-api/migration-wordpress/libs/extractItems.ts
@@ -365,7 +365,10 @@ const extractItems = async (item: any, config: DataConfig, type: string, affix: 
         // Track processed similar blocks to avoid duplicates
         
         for (const field of blocksJson) {
-            const fieldUid = getFieldUid(`${field?.name}${stableSuffix(field)}`|| '', affix || '');
+            // Guard a missing block name (freeform/whitespace separators parse with name: null)
+            // so the UID never gets a literal "undefined" prefix.
+            const blockName = field?.name || 'block';
+            const fieldUid = getFieldUid(`${blockName}${stableSuffix(field)}`, affix || '');
             const contentstackFieldName = getFieldName(resolveBlockName(field));
 
             const similarBlocks = findSimilarBlocks(result, field?.clientId);
@@ -428,7 +431,7 @@ const extractItems = async (item: any, config: DataConfig, type: string, affix: 
                 // No duplicate found - add the modular block child
                 if(Schema?.length > 0){
                   CT?.push?.({
-                  "uid": `modular_blocks.${getFieldUid(`${field?.name}${stableSuffix(field)}`, affix)}`,
+                  "uid": `modular_blocks.${getFieldUid(`${blockName}${stableSuffix(field)}`, affix)}`,
                   "backupFieldUid": `modular_blocks.${fieldUid}`,
                   "contentstackFieldUid": `modular_blocks.${fieldUid}`,
                   "otherCmsField": contentstackFieldName,
@@ -484,7 +487,7 @@ const extractItems = async (item: any, config: DataConfig, type: string, affix: 
                 // No duplicate found - add the modular block child
                 if(Schema?.length > 0){ 
                   CT?.push?.({
-                  "uid": `modular_blocks.${getFieldUid(`${field?.name}${stableSuffix(field)}`, affix)}`,
+                  "uid": `modular_blocks.${getFieldUid(`${blockName}${stableSuffix(field)}`, affix)}`,
                   "backupFieldUid": `modular_blocks.${fieldUid}`,
                   "contentstackFieldUid": `modular_blocks.${fieldUid}`,
                   "otherCmsField": contentstackFieldName,

--- a/upload-api/migration-wordpress/libs/extractItems.ts
+++ b/upload-api/migration-wordpress/libs/extractItems.ts
@@ -5,7 +5,7 @@ import * as cheerio from 'cheerio';
 
 
 import { setupWordPressBlocks } from "../utils/parseUtil";
-import { clientIdForUid, getFieldName, getFieldUid, schemaMapper } from "./schemaMapper";
+import { stableSuffix, getFieldName, getFieldUid, schemaMapper } from "./schemaMapper";
 import helper from "../utils/helper";
 import config from '../config/index.json';
 import extractTaxonomy from './extractTaxonomy';
@@ -365,7 +365,7 @@ const extractItems = async (item: any, config: DataConfig, type: string, affix: 
         // Track processed similar blocks to avoid duplicates
         
         for (const field of blocksJson) {
-            const fieldUid = getFieldUid(`${field?.name}_${clientIdForUid(field?.clientId)}`|| '', affix || '');
+            const fieldUid = getFieldUid(`${field?.name}${stableSuffix(field)}`|| '', affix || '');
             const contentstackFieldName = getFieldName(resolveBlockName(field));
 
             const similarBlocks = findSimilarBlocks(result, field?.clientId);
@@ -428,7 +428,7 @@ const extractItems = async (item: any, config: DataConfig, type: string, affix: 
                 // No duplicate found - add the modular block child
                 if(Schema?.length > 0){
                   CT?.push?.({
-                  "uid": `modular_blocks.${getFieldUid(`${field?.name}_${clientIdForUid(field?.clientId)}`, affix)}`,
+                  "uid": `modular_blocks.${getFieldUid(`${field?.name}${stableSuffix(field)}`, affix)}`,
                   "backupFieldUid": `modular_blocks.${fieldUid}`,
                   "contentstackFieldUid": `modular_blocks.${fieldUid}`,
                   "otherCmsField": contentstackFieldName,
@@ -484,7 +484,7 @@ const extractItems = async (item: any, config: DataConfig, type: string, affix: 
                 // No duplicate found - add the modular block child
                 if(Schema?.length > 0){ 
                   CT?.push?.({
-                  "uid": `modular_blocks.${getFieldUid(`${field?.name}_${clientIdForUid(field?.clientId)}`, affix)}`,
+                  "uid": `modular_blocks.${getFieldUid(`${field?.name}${stableSuffix(field)}`, affix)}`,
                   "backupFieldUid": `modular_blocks.${fieldUid}`,
                   "contentstackFieldUid": `modular_blocks.${fieldUid}`,
                   "otherCmsField": contentstackFieldName,

--- a/upload-api/migration-wordpress/libs/schemaMapper.ts
+++ b/upload-api/migration-wordpress/libs/schemaMapper.ts
@@ -1,6 +1,7 @@
 import { Field, WordPressBlock } from '../interface/interface';
 import restrictedUid from '../utils/index';
 import GenerateSchema from 'generate-schema';
+import { MAX_SUFFIX_LEN } from '../constants/index';
 
 const MEDIA_BLOCK_NAMES = ['core/image', 'core/video', 'core/audio', 'core/file'];
 
@@ -60,8 +61,6 @@ const slugifyIdentifier = (value: unknown): string => {
         .replace(/^_+|_+$/g, '');
 };
 
-/** Cap for the identity suffix so UIDs stay short. */
-const MAX_SUFFIX_LEN = 40;
 
 /**
  * Deterministic, iteration-stable suffix for a block's field UID.

--- a/upload-api/migration-wordpress/libs/schemaMapper.ts
+++ b/upload-api/migration-wordpress/libs/schemaMapper.ts
@@ -50,6 +50,46 @@ export function clientIdForUid(clientId: string | undefined): string {
     const compact = clientId?.replace?.(/-/g, '')?.toLowerCase();
     return compact?.slice?.(0, 4) || '0';
 }
+
+/** Slugify an author-supplied identifier into a UID-safe token (lowercase, `_`-joined). */
+const slugifyIdentifier = (value: unknown): string => {
+    if (value == null) return '';
+    return String(value)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+};
+
+/** Cap for the identity suffix so UIDs stay short. */
+const MAX_SUFFIX_LEN = 40;
+
+/**
+ * Deterministic, iteration-stable suffix for a block's field UID.
+ *
+ * The UID used to embed `clientIdForUid(block.clientId)`, but Gutenberg's parse()
+ * mints a fresh random clientId on every parse — so the UID changed on each
+ * re-migration and Contentstack treated the field as brand new, never updating
+ * the existing content on a 2nd iteration.
+ *
+ * This keys off `attributes.metadata.name` — the explicit author "Rename block"
+ * label — which survives re-parse, content edits, and reordering. It is the ONLY
+ * attribute the block de-duplication (`resolveBlockName`) uses to decide whether
+ * two same-named blocks are separate fields, so it is the correct — and only
+ * meaningful — disambiguator.
+ *
+ * We deliberately do NOT use `anchor`/`id`: those don't affect field separation
+ * and are frequently auto-derived from the block's text, which would make UIDs
+ * long and couple them to content (an edit would change the UID). Anonymous
+ * blocks therefore get NO suffix — the block name alone is a stable, unique UID
+ * within its scope.
+ *
+ * Returns a leading-underscore token (e.g. "_hero") or "" when anonymous, so
+ * callers can append it directly after the block name.
+ */
+export function stableSuffix(key: any): string {
+    const identity = slugifyIdentifier(key?.attributes?.metadata?.name).slice(0, MAX_SUFFIX_LEN);
+    return identity ? `_${identity}` : '';
+}
   
 
 async function processInnerBlocks(key: WordPressBlock, parentUid: string | null = null, parentFieldName: string | null = null, affix: string | null = null): Promise<any[]> {
@@ -207,8 +247,8 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
         case 'core/verse':
         case 'core/code': {
             const rteUid = parentUid ?
-            `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}`
-            : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`
+            : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
             return {
                 uid: rteUid,
                 otherCmsField: getFieldName(key?.name),
@@ -223,8 +263,8 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
         }
         case 'core/missing':
             const rteUid = parentUid ?
-                `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}`
-                : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+                `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`
+                : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
             if(key?.attributes?.originalName === 'jetpack/markdown'){
                 return {
                     uid: rteUid,
@@ -296,7 +336,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
         case 'core/audio':
         case 'core/video':
         case 'core/file': {
-            const fileUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const fileUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
             
             return {
                 uid: fileUid,
@@ -314,7 +354,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
         case 'core/heading':
         case 'core/accordion-heading':
         case 'core/list-item': {
-            const textUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const textUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
             return {
                 uid: textUid,
                 otherCmsField: getFieldName(key?.name),
@@ -331,7 +371,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
         case 'core/social-link':
         case 'core/navigation-link': {
            
-            const LinkUid = parentUid ? `${parentUid}.${getFieldUid(key?.name, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const LinkUid = parentUid ? `${parentUid}.${getFieldUid(key?.name, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
             return {
                 uid: LinkUid,
                 otherCmsField: getFieldName(key?.name),
@@ -377,7 +417,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
             }
 
             const groupSchema: Field[] = [];
-            const groupUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const groupUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
 
             const innerBlocks = await processInnerBlocks(
                 key,
@@ -423,7 +463,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
         case 'core/accordion-panel':
         case 'core/navigation': {
             const groupSchema: Field[] = [];
-            const groupUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const groupUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
 
             const innerBlocks = await processInnerBlocks(
                 key, 
@@ -465,14 +505,14 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
             const coverSchema: Field[] = []
             if(key?.attributes?.url){
                 coverSchema.push({
-                uid: `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}`,
+                uid: `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`,
                 otherCmsField: 'media',
                 otherCmsType: getFieldName(key?.attributes?.metadata?.name ?? key?.name),
                 contentstackField: 'media',
-                contentstackFieldUid: `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}`,
+                contentstackFieldUid: `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`,
                 contentstackFieldType: 'file',
                 backupFieldType: 'file',
-                backupFieldUid: `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}`,
+                backupFieldUid: `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`,
                 advanced: {}
                 });
             }
@@ -498,7 +538,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
           
         
         case 'core/search': {
-            const searchEleUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const searchEleUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
             const searchEle = await processAttributes(key, searchEleUid,fieldName, affix);
             const groupSchema: Field[] = [];
             searchEle?.length > 0 && groupSchema?.push({
@@ -526,7 +566,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
            
         case 'core/button': {
             const fieldName = parentFieldName ? `${parentFieldName} > ${getFieldName(key?.attributes?.metadata?.name ?? key?.name)}` :  `${getFieldName(key?.attributes?.metadata?.name ?? key?.name)}` ;
-            const buttonUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const buttonUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
 
             return { 
                 uid: buttonUid,
@@ -544,7 +584,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
         
         case 'core/buttons': { 
             const groupSchema: Field[] = [];
-            const groupUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const groupUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
 
             const innerBlocks = await processInnerBlocks(
                 key, 
@@ -556,12 +596,12 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
                 const items = Array.isArray(innerBlocks[0]) ? innerBlocks[0] : [innerBlocks[0]];
                 items?.forEach((item: Field) => {
                     
-                    item.uid = `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}`;
+                    item.uid = `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`;
                     item.otherCmsField = getFieldName(resolveBlockName(key));
                     item.otherCmsType = getFieldName(resolveBlockName(key));
                     item.contentstackField = `${parentFieldName} > ${getFieldName(resolveBlockName(key))}`;
-                    item.contentstackFieldUid = `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}`;
-                    item.backupFieldUid = `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}`;
+                    item.contentstackFieldUid = `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`;
+                    item.backupFieldUid = `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`;
                 });
                 return items;
             }
@@ -596,7 +636,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
 
         case 'core/media-text': {
             const mediaTextSchema: Field[] = [];
-            const mediaTextUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix)}` : getFieldUid(`${key?.name}_${clientIdForUid(key?.clientId)}`, affix);
+            const mediaTextUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
             const innerBlocks =
                 key?.innerBlocks && key?.innerBlocks?.length > 0
                     ? await processInnerBlocks(key, parentUid, parentFieldName, affix)

--- a/upload-api/migration-wordpress/libs/schemaMapper.ts
+++ b/upload-api/migration-wordpress/libs/schemaMapper.ts
@@ -595,13 +595,13 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
             if (innerBlocks?.length === 1) {
                 const items = Array.isArray(innerBlocks[0]) ? innerBlocks[0] : [innerBlocks[0]];
                 items?.forEach((item: Field) => {
-                    
-                    item.uid = `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`;
+
+                    item.uid = groupUid;
                     item.otherCmsField = getFieldName(resolveBlockName(key));
                     item.otherCmsType = getFieldName(resolveBlockName(key));
                     item.contentstackField = `${parentFieldName} > ${getFieldName(resolveBlockName(key))}`;
-                    item.contentstackFieldUid = `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`;
-                    item.backupFieldUid = `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}`;
+                    item.contentstackFieldUid = groupUid;
+                    item.backupFieldUid = groupUid;
                 });
                 return items;
             }

--- a/upload-api/migration-wordpress/libs/schemaMapper.ts
+++ b/upload-api/migration-wordpress/libs/schemaMapper.ts
@@ -371,7 +371,7 @@ async function schemaMapper (key: WordPressBlock | WordPressBlock[], parentUid: 
         case 'core/social-link':
         case 'core/navigation-link': {
            
-            const LinkUid = parentUid ? `${parentUid}.${getFieldUid(key?.name, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
+            const LinkUid = parentUid ? `${parentUid}.${getFieldUid(`${key?.name}${stableSuffix(key)}`, affix)}` : getFieldUid(`${key?.name}${stableSuffix(key)}`, affix);
             return {
                 uid: LinkUid,
                 otherCmsField: getFieldName(key?.name),

--- a/upload-api/tests/unit/migration-wordpress/schemaMapper.test.ts
+++ b/upload-api/tests/unit/migration-wordpress/schemaMapper.test.ts
@@ -212,9 +212,9 @@ describe('schemaMapper', () => {
       const result = await schemaMapper(block, 'page', 'Page', affix);
 
       result.forEach((field: any) => {
-        expect(field.contentstackFieldUid).toBe(`page.${getFieldUid('core/buttons_btns', affix)}`);
-        expect(field.uid).toBe(`page.${getFieldUid('core/buttons_btns', affix)}`);
-        expect(field.backupFieldUid).toBe(`page.${getFieldUid('core/buttons_btns', affix)}`);
+        expect(field.contentstackFieldUid).toBe(`page.${getFieldUid('core/buttons', affix)}`);
+        expect(field.uid).toBe(`page.${getFieldUid('core/buttons', affix)}`);
+        expect(field.backupFieldUid).toBe(`page.${getFieldUid('core/buttons', affix)}`);
         expect(field.contentstackField).toContain('Page > ');
       });
     });
@@ -259,7 +259,7 @@ describe('schemaMapper', () => {
 
       expect(Array.isArray(result)).toBe(true);
       const p = result[0] as any;
-      expect(p.uid).toMatch(/^panel_uid\.paragraph_/);
+      expect(p.uid).toBe('panel_uid.paragraph');
       expect(p.contentstackField).toBe('Panel > paragraph');
     });
 


### PR DESCRIPTION
## 🔗 Jira Ticket

> Replace with your ticket link — required before requesting review.

[MIGRATION-XXXX](https://contentstack.atlassian.net/browse/MIGRATION-XXXX)

---

## 📋 PR Type

<!-- Check all that apply -->

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

This PR enhances the WordPress migration pipeline by improving UID generation and filtering logic across the extraction and schema mapping flow. These changes help ensure only relevant WordPress content is processed while generating stable and unique UIDs for migrated entries.

### What changed?

- Enhanced UID generation in `extractEntries` to produce consistent and unique entry identifiers.
- Improved filtering logic in `extractItems` to process only supported WordPress items.
- Updated `schemaMapper` to work with the new UID generation and filtering behavior.
- Improved the overall migration flow for better data consistency and reduced unnecessary processing.

### Why?

The previous implementation could process unsupported items and generate inconsistent UIDs in certain scenarios. This enhancement improves migration accuracy, prevents duplicate or unstable entry identifiers, and ensures cleaner data mapping to Contentstack.

---

## 🧪 Testing

- [x] Verified unique UID generation for migrated entries.
- [x] Tested extraction with multiple WordPress export files.
- [x] Confirmed unsupported items are filtered out correctly.
- [x] Validated successful schema mapping after the changes.
- [x] Performed regression testing to ensure existing migration behavior remains unaffected.

---

## 📸 Screenshots / Logs (if applicable)

N/A

---

## ✅ Checklist

- [x] Code follows project coding standards.
- [x] Self-reviewed the changes.
- [x] Tested locally.
- [x] Existing functionality verified.
- [ ] Documentation updated (if applicable).