### PR TITLE
Delta bug fix

### DIFF
--- a/ui/src/components/ContentMapper/assetMapper.tsx
+++ b/ui/src/components/ContentMapper/assetMapper.tsx
@@ -19,11 +19,10 @@ import {
 import { RootState } from '../../store';
 
 // Utilities
-import { ASSET_MAPPER_EMPTY_STATE } from '../../utilities/constants';
+import { ASSET_MAPPER_EMPTY_STATE, MAPPER_SEARCH_EMPTY_STATE } from '../../utilities/constants';
 
 // Interface
 import { AssetMapperType, TableTypes, UidMap } from './contentMapper.interface';
-import { ItemStatusMapProp } from '@contentstack/venus-components/build/components/Table/types';
 
 // Styles and Assets
 import { NoDataFound } from '../../common/assets';
@@ -42,10 +41,8 @@ import {
 import './index.scss';
 
 const AssetMapper = ({
-  tableHeight,
   onCountChange,
 }: {
-  tableHeight: number;
   onCountChange?: (count: number) => void;
 }) => {
   const { projectId = '' } = useParams<{ projectId: string }>();
@@ -56,33 +53,37 @@ const AssetMapper = ({
   const [tableData, setTableData] = useState<AssetMapperType[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [totalCounts, setTotalCounts] = useState<number>(0);
-  const [itemStatusMap, setItemStatusMap] = useState({});
   const [rowIds, setRowIds] = useState<Record<string, boolean>>({});
   const [persistedRowIds, setPersistedRowIds] = useState<Record<string, boolean>>({});
   const [isLoadingSaveButton, setisLoadingSaveButton] = useState<boolean>(false);
   // True once the initial fetch has settled — used to gate the empty state so it
   // doesn't flash before assets have loaded.
   const [hasFetched, setHasFetched] = useState<boolean>(false);
+  // Current search term driven by the table. When a search is active we keep the
+  // table (and its search box) mounted even on 0 results, otherwise the user is
+  // stranded on the full-page empty state with no way to clear the search.
+  const [searchText, setSearchText] = useState<string>('');
 
   useEffect(() => {
-    fetchAssets('');
+    fetchAssets('', { seedSelection: true });
   }, []);
 
-  const fetchAssets = async (searchText: string) => {
+  // Single server-paginated fetch (same pattern as entryMapper's fetchEntries). The
+  // Venus table drives paging by calling fetchData with { skip, limit, searchText };
+  // we ask the API for just that page and use the returned `count` as the grand total.
+  //
+  // seedSelection: only on the initial load do we seed rowIds/persistedRowIds from the
+  // server's persisted selection. On search / page change we instead re-apply the
+  // user's current (possibly unsaved) selection so nothing gets wiped.
+  const fetchAssets = async (
+    searchVal: string,
+    { skip = 0, limit = 30, seedSelection = false }: { skip?: number; limit?: number; seedSelection?: boolean } = {},
+  ) => {
     try {
-      const statusMap: ItemStatusMapProp = {};
-      for (let index = 0; index <= 1000; index++) {
-        statusMap[index] = 'loading';
-      }
-      setItemStatusMap(statusMap);
       setLoading(true);
 
-      const { data } = await getAssetMapping(0, 1000, searchText ?? '', projectId);
+      const { data } = await getAssetMapping(skip, limit, searchVal ?? '', projectId);
 
-      for (let index = 0; index <= 1000; index++) {
-        statusMap[index] = 'loaded';
-      }
-      setItemStatusMap({ ...statusMap });
       setLoading(false);
 
       const validTableData: AssetMapperType[] = mapAssetsToRows(data?.assetMapping);
@@ -91,60 +92,33 @@ const AssetMapper = ({
       // sends back. Use that so the count and pagination are correct when the
       // result set is larger than the requested page size.
       const total = data?.count ?? validTableData?.length ?? 0;
+      setTotalCounts(total);
+      onCountChange?.(total);
+      setHasFetched(true);
+
+      if (!seedSelection) {
+        // Re-apply the user's current selection onto the freshly fetched page;
+        // don't touch rowIds/persistedRowIds so nothing gets deselected.
+        setTableData(applySelectionToAssets(validTableData ?? [], rowIds));
+        return;
+      }
 
       const initialSelected = buildSelectedRowIds(validTableData ?? []);
       setTableData(validTableData ?? []);
       setRowIds(initialSelected);
       setPersistedRowIds(initialSelected);
-      setTotalCounts(total);
-      onCountChange?.(total);
-      setHasFetched(true);
     } catch (error) {
       console.error('fetchAssets -> error', error);
+      setLoading(false);
       setHasFetched(true);
     }
   };
 
-  // Fetch table data
-  const fetchData = async ({ searchText }: TableTypes) => {
-    fetchAssets(searchText ?? '');
-  };
-
-  // Method for Load more table data
-  const loadMoreItems = async ({ searchText, skip, limit, startIndex, stopIndex }: TableTypes) => {
-    try {
-      const itemStatusMapCopy: ItemStatusMapProp = { ...itemStatusMap };
-      for (let index = startIndex; index <= stopIndex; index++) {
-        itemStatusMapCopy[index] = 'loading';
-      }
-      setItemStatusMap({ ...itemStatusMapCopy });
-      setLoading(true);
-
-      const { data } = await getAssetMapping(skip, limit, searchText ?? '', projectId);
-
-      const updateditemStatusMapCopy: ItemStatusMapProp = { ...itemStatusMap };
-      for (let index = startIndex; index <= stopIndex; index++) {
-        updateditemStatusMapCopy[index] = 'loaded';
-      }
-      setItemStatusMap({ ...updateditemStatusMapCopy });
-      setLoading(false);
-
-      const validTableData: AssetMapperType[] = mapAssetsToRows(data?.assetMapping);
-      const newRows = applySelectionToAssets(validTableData ?? [], rowIds);
-
-      // Merge the fetched page into the existing rows at its offset so the
-      // virtualized table keeps previously loaded rows instead of dropping
-      // them when the next range is requested.
-      setTableData((prev) => {
-        const merged = [...(prev ?? [])];
-        newRows.forEach((row, index) => {
-          merged[Number(skip) + index] = row;
-        });
-        return merged;
-      });
-    } catch (error) {
-      console.error('loadMoreItems -> error', error);
-    }
+  // Driven by the table: page change, rows-per-page change, and search all land here.
+  const fetchData = async ({ searchText: search, skip, limit }: TableTypes) => {
+    setSearchText(search ?? '');
+    // Searching / paging must not drop the user's in-progress selection.
+    fetchAssets(search ?? '', { skip, limit });
   };
 
   /**
@@ -263,32 +237,33 @@ const AssetMapper = ({
       ),
       accessor: accessorAssetName,
       id: 'uuid',
-      width: '220px',
+      width: '400px',
     },
     {
       disableSortBy: true,
       Header: (<span>{'Path:'}</span>),
       accessor: accessorAssetPath,
-      id: '1'
+      id: '1',
+      width: '550px',
     },
     {
       disableSortBy: true,
       Header: (<span>{'Size:'}</span>),
       accessor: accessorFileSize,
       id: '2',
-      width: '100px',
+      width: '120px',
     },
     {
       disableSortBy: true,
       Header: (<span>{'Contentstack UIDs:'}</span>),
       accessor: accessorContentstackUid,
-      id: '3'
+      id: '3',
     }
   ];
 
   return (
     <div className="step-container">
-      {(hasFetched && !loading && totalCounts === 0) ?
+      {(hasFetched && !loading && totalCounts === 0 && !searchText) ?
         <EmptyState
           forPage="emptyStateV2"
           heading={<div className="empty_search_heading">{ASSET_MAPPER_EMPTY_STATE.NO_ASSETS_HEADING}</div>}
@@ -302,9 +277,10 @@ const AssetMapper = ({
           version="v2"
           testId="no-results-found-page"
         /> :
-        <div className='entry-mapper-container'>
+        <div>
           <InfiniteScrollTable
             key={'asset-mapper-table'}
+            className={'asset-mapper-table'}
             loading={loading}
             canSearch={true}
             totalCounts={Math.max(0, totalCounts)}
@@ -313,23 +289,34 @@ const AssetMapper = ({
             uniqueKey={'id'}
             isRowSelect={true}
             fullRowSelect={true}
-            itemStatusMap={itemStatusMap}
             fetchTableData={fetchData}
-            loadMoreItems={loadMoreItems}
-            tableHeight={tableHeight}
+            tableHeight={400}
             equalWidthColumns={false}
             columnSelector={false}
+            v2Features={{ pagination: true, isNewEmptyState: true }}
+            rowPerPageOptions={[10, 30, 50, 100]}
+            minBatchSizeToFetch={30}
             initialSelectedRowIds={rowIds}
-            itemSize={80}
+            itemSize={60}
             getSelectedRow={handleSelectedAssets}
             rowSelectCheckboxProp={{ key: '_canSelect', value: true }}
             name={{
               singular: '',
               plural: `${totalCounts === 0 ? 'Count' : ''}`
             }}
+            customEmptyState={
+              <EmptyState
+                forPage="list"
+                heading={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_HEADING}
+                description={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_DESCRIPTION}
+                moduleIcon={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_ICON}
+                type="secondary"
+                className="custom-empty-state"
+              />
+            }
           />
           <div className="mapper-footer">
-            <div>Total Assets: <strong>{totalCounts}</strong></div>
+            <div></div>
             <Button
               className="saveButton"
               onClick={handleSaveAssets}

--- a/ui/src/components/ContentMapper/entryAssetMapper.tsx
+++ b/ui/src/components/ContentMapper/entryAssetMapper.tsx
@@ -22,9 +22,6 @@ interface entryAssetMapperProps {
 const EntryAssetMapper = ({ handleStepChange }: entryAssetMapperProps) => {
   const [mapperView, setMapperView] = useState<'entries' | 'assets'>('entries');
 
-  const calcHeight = () => window.innerHeight - 361;
-  const tableHeight = calcHeight();
-
   return (
     // Plain flex-column wrapper — NOT .step-container. Both child mappers render their own
     // .step-container (height: 100%), so reusing it here would nest two full-height flex
@@ -51,7 +48,7 @@ const EntryAssetMapper = ({ handleStepChange }: entryAssetMapperProps) => {
       </div>
 
       {mapperView === 'assets' ? (
-        <AssetMapper tableHeight={tableHeight} />
+        <AssetMapper />
       ) : (
         <EntryMapper handleStepChange={handleStepChange} />
       )}

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -30,7 +30,7 @@ import { RootState } from '../../store';
 import { updateMigrationData, updateNewMigrationData } from '../../store/slice/migrationDataSlice';
 
 // Utilities
-import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping, ENTRY_MAPPER_EMPTY_STATE } from '../../utilities/constants';
+import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping, ENTRY_MAPPER_EMPTY_STATE, MAPPER_SEARCH_EMPTY_STATE } from '../../utilities/constants';
 import { validateArray } from '../../utilities/functions';
 
 // Interface
@@ -232,7 +232,9 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
       setContentTypes(next);
       setFilteredContentTypes(next);
       setCount(next?.length ?? 0);
-      if (!next?.length) clearEntryTableState();
+      // When the search matches no content types, keep the currently-selected content
+      // type and its entries on the right — only the left list shows "No Content Types
+      // Found." Clearing the table here would strand the user on "No Records Found".
     } catch (error) {
       console.error(error);
       return error;
@@ -504,7 +506,7 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
       </div>
       :
       <div className="step-container">
-        {(contentTypes?.length > 0 || tableData?.length > 0) ?
+        {(contentTypes?.length > 0 || tableData?.length > 0 || searchContentType?.length > 0) ?
           <div className="d-flex flex-wrap table-container">
             {/* Content Types List */}
             <div className="content-types-list-wrapper">
@@ -660,6 +662,16 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
                       singular: '',
                       plural: `${totalCounts === 0 ? 'Count' : ''}`
                     }}
+                    customEmptyState={
+                      <EmptyState
+                        forPage="list"
+                        heading={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_HEADING}
+                        description={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_DESCRIPTION}
+                        moduleIcon={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_ICON}
+                        type="secondary"
+                        className="custom-empty-state"
+                      />
+                    }
                   />
                   {(totalCounts > 0 || (tableData?.length ?? 0) > 0) && (
                     <div className="mapper-footer">

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -440,6 +440,57 @@ div .table-row {
   line-height: 1.2 !important;
 }
 
+// Center the search-empty state vertically. With v2Features.isNewEmptyState on, Venus
+// wraps customEmptyState in `.Table__centerWrapper` inside the table body. The wrapper
+// collapses to content height, so make the body a flex column and let the wrapper grow
+// to fill it, then center its own content.
+.entry-mapper-container .Table:has(.Table__centerWrapper) .Table__body {
+  display: flex;
+  flex-direction: column;
+}
+
+.entry-mapper-container .Table__centerWrapper {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 0;
+  // Nudge the empty state slightly above dead-center so it reads a touch higher.
+  padding-bottom: 6rem;
+}
+
+// Field mapping table (Map Content Fields step): center the search-empty state. Anchor on
+// the venus .Table and take .Table__centerWrapper out of flow (position: absolute) so it
+// overlays the full table area and centers, instead of stacking under the header rows.
+.field-mapper-container .Table:has(.Table__centerWrapper) {
+  position: relative;
+  // Absolute-positioned .Table__centerWrapper adds no height, so give the table an
+  // explicit tall area to center the empty state within.
+  height: calc(100vh - 300px);
+
+  .Table__centerWrapper {
+    position: absolute !important;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+// Asset mapper table: venus's .Table sets min-height: 31.25rem, forcing the table
+// tall and pushing the pagination bar down with a dead gap. Pin an explicit height
+// so the table + pagination end where we want and the Save button can sit below.
+.entry-asset-mapper .step-container .Table {
+  height: 400px !important;
+  min-height: 0px !important;
+}
+
 .custom-empty-state {
   .Icon--original {
     width: 207px !important;
@@ -572,7 +623,7 @@ div .table-row {
 .entry-mapper-container {
   // Empty state: venus renders "No Records Found" (.EmptyState) with no scroll body, so
   // the table collapses. Give .Table an explicit height so it fills like ExecutionLogs.
-  .Table:has(.EmptyState) {
+  &:not(.asset-mapper-container) .Table:has(.EmptyState) {
     height: calc(100vh - 22rem) !important;
   }
 
@@ -580,8 +631,10 @@ div .table-row {
   // prop: this keeps the venus pagination bar (a sibling below the body) visible while
   // the body scrolls internally. Height fits a full page and reserves room for the
   // search row, pagination bar and Save footer.
-  .Table__body,
-  .Table.TableWithPaginated .Table__body {
+  // Entry mapper only — the asset mapper lets venus size the body from its measured
+  // tableHeight prop, and this !important would override those inline styles.
+  &:not(.asset-mapper-container) .Table__body,
+  &:not(.asset-mapper-container) .Table.TableWithPaginated .Table__body {
     height: calc(100vh - 520px) !important;
     max-height: calc(100vh - 520px) !important;
   }

--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -41,7 +41,7 @@ import { RootState } from '../../store';
 import { updateMigrationData, updateNewMigrationData } from '../../store/slice/migrationDataSlice';
 
 // Utilities
-import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping, CONTENT_MAPPER_EMPTY_STATE } from '../../utilities/constants';
+import { CS_ENTRIES, CONTENT_MAPPING_STATUS, STATUS_ICON_Mapping, CONTENT_MAPPER_EMPTY_STATE, MAPPER_SEARCH_EMPTY_STATE } from '../../utilities/constants';
 import { isEmptyString, validateArray } from '../../utilities/functions';
 import useBlockNavigation from '../../hooks/userNavigation';
 
@@ -3289,7 +3289,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
       </div>
       :
       <div className="step-container">
-        {(contentTypes?.length > 0 || tableData?.length > 0) ?
+        {(contentTypes?.length > 0 || tableData?.length > 0 || searchContentType?.length > 0) ?
           <div className="d-flex flex-wrap table-container">
             {/* Content Types List */}
             <div className="content-types-list-wrapper">
@@ -3405,7 +3405,7 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
             {/* Content Type Fields */}
             <div className="content-types-fields-wrapper">
               <div className="table-wrapper" ref={tableWrapperRef}>
-                  <div>
+                  <div className="field-mapper-container">
                 <InfiniteScrollTable
                   loading={loading}
                   canSearch={true}
@@ -3465,10 +3465,21 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                   }}
                   getSelectedRow={handleSelectedEntries}
                   rowSelectCheckboxProp={{ key: '_canSelect', value: true }}
+                  v2Features={{ isNewEmptyState: true }}
                   name={{
                     singular: '',
                     plural: `${totalCounts === 0 ? 'Count' : ''}`
                   }}
+                  customEmptyState={
+                    <EmptyState
+                      forPage="list"
+                      heading={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_HEADING}
+                      description={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_DESCRIPTION}
+                      moduleIcon={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_ICON}
+                      type="secondary"
+                      className="custom-empty-state"
+                    />
+                  }
                 />
                 {totalCounts > 0 && (
                   <div className="mapper-footer">

--- a/ui/src/utilities/constants.ts
+++ b/ui/src/utilities/constants.ts
@@ -215,6 +215,14 @@ export const ENTRY_MAPPER_EMPTY_STATE = {
     'There are no entries available to map for the already-migrated content types. You can still continue.'
 }
 
+// Shared "search returned nothing" empty state for the mapper tables — mirrors the
+// ExecutionLogs NO_MATCH state so a zero-result search reads consistently across the app.
+export const MAPPER_SEARCH_EMPTY_STATE = {
+  NO_MATCH_HEADING: 'No matching result found',
+  NO_MATCH_DESCRIPTION: 'Try changing the search query to find what you are looking for.',
+  NO_MATCH_ICON: 'NoSearchResult'
+}
+
 // Asset Mapper (Map Entry step → Assets tab) empty-state text.
 export const ASSET_MAPPER_EMPTY_STATE = {
   NO_ASSETS_HEADING: 'No assets available for mapping',

--- a/upload-api/src/config/index.json
+++ b/upload-api/src/config/index.json
@@ -4,7 +4,7 @@
       "optionLimit": 100
     }
   },
-  "cmsType": "sitecore",
+  "cmsType": "cmsType",
   "isLocalPath": true,
   "awsData": {
     "awsRegion": "us-east-2",
@@ -25,5 +25,5 @@
     "base_url": "drupal_assets_base_url",
     "public_path": "drupal_assets_public_path"
   },
-  "localPath": "/Users/yash.shinde/Documents/Migration/Expample-Data/Sitecore/delta/airports_only_add_v1.zip"
+  "localPath": "your_local_cms_data_path"
 }


### PR DESCRIPTION
## 🔗 Jira Ticket

> Replace with your ticket link — required before requesting review.

[MIGRATION-1091](https://contentstack.atlassian.net/browse/MIGRATION-1091)

---

## 📋 PR Type

<!-- Check all that apply -->

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [x] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

<!-- A clear and concise summary of what this PR does and why. -->

### What changed?

<!-- Describe the changes in bullet points -->

- **New "no matching result" empty state for search** across ContentMapper, EntryMapper, and AssetMapper — added a shared `MAPPER_SEARCH_EMPTY_STATE` constant and wired `v2Features={{ isNewEmptyState: true }}` + a `customEmptyState` into all three mapper tables so a zero-result search shows a consistent centered empty state.
- Kept the table + search box mounted on 0 results (render guards now include `searchText` / `searchContentType`), so the user can clear the search instead of being stranded on the full-page empty state.
- EntryMapper: a no-match content-type search now keeps the selected content type and its entries instead of clearing the table.
- **Refactored the asset mapper from infinite scroll to server-side pagination** — replaced the fetch-1000-rows + `itemStatusMap` + `loadMoreItems` model with a single paginated `fetchAssets({ skip, limit, seedSelection })` (same pattern as EntryMapper), added `v2Features.pagination`, `rowPerPageOptions`, and `minBatchSizeToFetch`.
- `seedSelection` preserves the user's in-progress selection across search / page changes.
- Removed the now-unused `tableHeight` prop from `AssetMapper` and `calcHeight` from `entryAssetMapper`.
- **CSS fixes (index.scss):** centered the search-empty state inside the venus `.Table__centerWrapper`; absolute-overlay centering for the field-mapper empty state; pinned the asset `.Table` height to remove the dead gap and keep the pagination bar + Save button visible; scoped the entry-mapper `!important` height rules with `:not(.asset-mapper-container)` so they stop overriding the asset table's sizing.
- Reverted local dev `cmsType` / `localPath` in `upload-api/src/config/index.json` back to placeholders.

### Why?

<!-- Context, motivation, or problem this solves -->

Search on the mapper tables showed a bare/absent empty state and could trap the user with no way to clear the query. The asset table also used a heavy infinite-scroll fetch (up to 1000 rows at once) with layout bugs — dead space above the footer, clipped pagination bar, and a lost Save button. This standardizes the empty state, moves assets onto the same paginated model as entries, and fixes the associated layout issues.

---

## 🧩 Affected Areas

<!-- Check all modules/layers that are touched -->

- [ ] `api` — Node.js backend
- [x] `ui` — React frontend
- [x] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [x] Environment variables / config
- [ ] Other: <!-- specify -->

---

## 🧪 How to Test

<!-- Step-by-step instructions for the reviewer to verify this change -->

1. Run a delta migration (iteration 2+) to reach the **Map Entry** step (shows the Entries / Assets toggle).
2. On each mapper table (Map Content Fields, Map Entry → Entries, Map Entry → Assets), type a search query that matches nothing.
3. Clear the search and confirm the full list returns.
4. On the **Assets** tab: page through results, change rows-per-page (10/30/50/100), toggle selections across pages, then Save.

**Expected result:**

A centered "No matching result found" empty state renders with the search box still available to clear. The asset table paginates server-side, selections persist across page/search changes until Save, and the table + pagination bar + Save button are all visible with no dead gap or overlap.

---

## 📸 Screenshots / Recordings

<!-- If UI changes are involved, attach before/after screenshots or a short screen recording -->

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

<!-- Link any PRs this depends on or is related to -->

-

---

## ✅ Author Checklist

> Complete this before moving the PR out of Draft.

- [x] Branch follows naming convention: `feature/`, `bugfix/`, or `hotfix/` + 5–30 lowercase chars
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added
- [x] No sensitive credentials or secrets committed
- [ ] Existing tests pass locally (`npm test`)
- [ ] New tests written (or not applicable — explain why)
- [ ] `README.md` / docs updated if behaviour changed
- [ ] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

<!-- Anything specific you'd like reviewers to focus on or be cautious about -->

- Asset mapper moved from infinite scroll to pagination — worth a close look at `fetchAssets` / `fetchData` and the `seedSelection` selection-preservation logic.
- Several CSS rules were scoped with `:not(.asset-mapper-container)` so entry-mapper `!important` heights stop fighting the asset table's venus-managed sizing — check both tables still size correctly.

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) · [Issues](https://github.com/contentstack/migration-v2/issues)
