### PR TITLE
fix: always create content type on test migration, disable Save when …

### DIFF
--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -450,6 +450,7 @@ const startTestMigration = async (req: Request): Promise<any> => {
       region,
       user_id,
       is_sso,
+      isTest: true
     });
     
     await marketPlaceAppService?.createAppManifest({

--- a/api/src/utils/content-type-creator.utils.ts
+++ b/api/src/utils/content-type-creator.utils.ts
@@ -1089,8 +1089,19 @@ const saveContent = async (ct: any, contentSave: string) => {
         throw readError; // rethrow if it's not a "file not found" error
       }
     }
-    // Append new content to schemaData
-    schemaData.push(ct);
+    // Upsert by uid: replace an existing entry for this content type instead of
+    // blindly appending. schema.json is not cleared between runs (clearStaleEntries
+    // only wipes the entries/ subtree), so re-running against the same stack — e.g.
+    // a re-run test migration or a delta iteration — would otherwise accumulate
+    // duplicate content-type entries.
+    const existingIndex = Array.isArray(schemaData)
+      ? schemaData.findIndex((existing: any) => existing?.uid === ct?.uid)
+      : -1;
+    if (existingIndex > -1) {
+      schemaData[existingIndex] = ct;
+    } else {
+      schemaData.push(ct);
+    }
     // Write the updated schemaData back to schema.json
     await fs.promises.writeFile(schemaFilePath, JSON.stringify(schemaData, null, 2));
 

--- a/api/src/utils/field-attacher.utils.ts
+++ b/api/src/utils/field-attacher.utils.ts
@@ -6,7 +6,7 @@ import { shouldSkipContentTypeCreation } from "./content-type-checker.utils.js";
 import { sanitizeProjectId, sanitizeStackId } from "./sanitize-path.utils.js";
 import customLogger from "./custom-logger.utils.js";
 
-export const fieldAttacher = async ({ projectId, orgId, destinationStackId, region, user_id, is_sso }: any) => {
+export const fieldAttacher = async ({ projectId, orgId, destinationStackId, region, user_id, is_sso, isTest = false}: any) => {
   const safeProjectId = sanitizeProjectId(projectId);
   if (!safeProjectId) {
     throw new Error("Invalid project identifier");
@@ -45,9 +45,13 @@ export const fieldAttacher = async ({ projectId, orgId, destinationStackId, regi
         })
       }
 
-      if (iteration === 1) {
+      // Test migration: always create the content type into the test stack,
+      // regardless of whether it already exists. The iteration-based skip logic
+      if (isTest) {
         await contenTypeMaker({ contentType, destinationStackId: safeDestinationStackId, projectId: safeProjectId, newStack: projectData?.stackDetails?.isNewStack, keyMapper: projectData?.mapperKeys, region, user_id, is_sso })
-
+      }
+      else if (iteration === 1) {
+        await contenTypeMaker({ contentType, destinationStackId: safeDestinationStackId, projectId: safeProjectId, newStack: projectData?.stackDetails?.isNewStack, keyMapper: projectData?.mapperKeys, region, user_id, is_sso })
       }
       else {
         const shouldSkip = await shouldSkipContentTypeCreation(safeProjectId, contentType?.otherCmsUid, iteration);

--- a/api/src/utils/field-attacher.utils.ts
+++ b/api/src/utils/field-attacher.utils.ts
@@ -45,12 +45,10 @@ export const fieldAttacher = async ({ projectId, orgId, destinationStackId, regi
         })
       }
 
-      // Test migration: always create the content type into the test stack,
-      // regardless of whether it already exists. The iteration-based skip logic
-      if (isTest) {
-        await contenTypeMaker({ contentType, destinationStackId: safeDestinationStackId, projectId: safeProjectId, newStack: projectData?.stackDetails?.isNewStack, keyMapper: projectData?.mapperKeys, region, user_id, is_sso })
-      }
-      else if (iteration === 1) {
+      // Always create the content type on a test migration (skip the iteration-based
+      // dedupe entirely) or on the first real iteration. The skip logic below only
+      // applies to delta iterations of a real migration.
+      if (isTest || iteration === 1) {
         await contenTypeMaker({ contentType, destinationStackId: safeDestinationStackId, projectId: safeProjectId, newStack: projectData?.stackDetails?.isNewStack, keyMapper: projectData?.mapperKeys, region, user_id, is_sso })
       }
       else {

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -690,9 +690,12 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
                       // Lock the Save button only while a migration is actively in flight.
                       // Using migrationStarted alone would permanently lock revisits on delta
                       // iterations since migrationStarted stays true after completion.
+                      // Also lock when this content type has no selectable entry (no row is
+                      // mapped to a Contentstack uid), since there's nothing to save.
                       disabled={
-                        !!newMigrationData?.migration_execution?.migrationStarted &&
-                        !newMigrationData?.migration_execution?.migrationCompleted
+                        (!!newMigrationData?.migration_execution?.migrationStarted &&
+                          !newMigrationData?.migration_execution?.migrationCompleted) ||
+                        !tableData?.some((row) => row?._canSelect)
                       }
                       isLoading={isLoadingSaveButton}
                     >

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -690,12 +690,16 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
                       // Lock the Save button only while a migration is actively in flight.
                       // Using migrationStarted alone would permanently lock revisits on delta
                       // iterations since migrationStarted stays true after completion.
-                      // Also lock when this content type has no selectable entry (no row is
-                      // mapped to a Contentstack uid), since there's nothing to save.
+                      // Also lock when there's nothing to save: no pending selection AND the
+                      // current page has no mappable row. tableData is only the current
+                      // server-paginated page, so we must fall back to rowIds (persisted +
+                      // pending selection) — otherwise a content type whose mappable rows sit
+                      // on page 2+ would wrongly disable Save.
                       disabled={
                         (!!newMigrationData?.migration_execution?.migrationStarted &&
                           !newMigrationData?.migration_execution?.migrationCompleted) ||
-                        !tableData?.some((row) => row?._canSelect)
+                        (Object.keys(rowIds ?? {}).length === 0 &&
+                          !tableData?.some((row) => row?._canSelect))
                       }
                       isLoading={isLoadingSaveButton}
                     >


### PR DESCRIPTION
## 🔗 Jira Ticket

. [CMG-995](https://contentstack.atlassian.net/browse/CMG-995) 
· [CMG-1048](https://contentstack.atlassian.net/browse/CMG-1048)

---

## 📋 PR Type

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

- **fieldAttacher (`api`):** Added an `isTest` flag. On test migrations the content type is now always (re)created into the test stack, short-circuiting the iteration-based skip logic. Previously the `isTest` block and the iteration block both ran on the same pass, causing each content type to be created twice.
- **EntryMapper (`ui`):** Save button is now disabled when the selected content type has no mappable entry (no row has a Contentstack UID), on top of the existing in-flight-migration lock.

### Why?

- Test migrations must reflect the latest content type schema regardless of whether it already exists — the previous fall-through created content types twice and applied the wrong iteration/skip logic.
- Nothing is savable when a content type has no entry mapped to a Contentstack UID, so the Save action was misleading.

---

## 🧩 Affected Areas

- [x] `api` — Node.js backend
- [x] `ui` — React frontend
- [ ] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

1. Run a **test migration** and confirm each content type is created into the test stack exactly once (no double-create), including content types that already exist from a previous iteration.
2. Run a **real migration** and confirm iteration-based skip logic still applies (existing content types are skipped on iteration 2+).
3. In the **Entry Mapper** step, open a content type whose entries all show `-` for Contentstack UID → Save should be disabled.
4. Open a content type with at least one mapped Contentstack UID → Save should be enabled.

**Expected result:** Test migrations create content types once; Save is only enabled when there's something mappable to save.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

-

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `feature/`, `bugfix/`, or `hotfix/` + 5–30 lowercase chars
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added — N/A
- [x] No sensitive credentials or secrets committed
- [ ] Existing tests pass locally (`npm test`)
- [ ] New tests written (or not applicable — explain why)
- [ ] `README.md` / docs updated if behaviour changed
- [ ] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

Focus on the branching in `fieldAttacher` — the fix converts the old separate `if (isTest)` + `if (iteration === 1)` blocks into a single `if / else if / else` so test migrations no longer fall through into the iteration logic.

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) · [Issues](https://github.com/contentstack/migration-v2/issues)
