### PR TITLE
CMG-1093 | Contentful migration got stuck some time

### DIFF
--- a/api/src/controllers/migration.controller.ts
+++ b/api/src/controllers/migration.controller.ts
@@ -25,6 +25,9 @@ const getAuditData = async (req: Request, res: Response): Promise<void> => {
  */
 const startTestMigration = async (req: Request, res: Response): Promise<void> => {
   const resp = migrationService.startTestMigration(req);
+  Promise.resolve(resp).catch((err) => {
+    console.error('startTestMigration failed', err);
+  });
   res.status(200).json(resp);
 };
 
@@ -38,6 +41,9 @@ const startTestMigration = async (req: Request, res: Response): Promise<void> =>
  */
 const startMigration = async (req: Request, res: Response): Promise<void> => {
   const resp = migrationService.startMigration(req);
+  Promise.resolve(resp).catch((err) => {
+    console.error('startMigration failed', err);
+  });
   res.status(200).json(resp);
 };
 

--- a/api/src/services/contentful.service.ts
+++ b/api/src/services/contentful.service.ts
@@ -830,6 +830,7 @@ const createAssets = async (packagePath: any, destination_stack_id: string, proj
       err
     )
     await customLogger(projectId, destination_stack_id, 'error', message);
+    throw err;
   }
 };
 

--- a/api/src/services/contentful.service.ts
+++ b/api/src/services/contentful.service.ts
@@ -335,11 +335,7 @@ async function readFile(filePath: string, fileName: string) {
  * @throws {Error} - If there is an error writing the file.
  */
 async function writeOneFile(indexPath: string, fileMeta: any) {
-  fs.writeFile(indexPath, JSON.stringify(fileMeta), (err) => {
-    if (err) {
-      console.error("Error writing file: 3", err);
-    }
-  });
+  await fs.promises.writeFile(indexPath, JSON.stringify(fileMeta));
 }
 
 /**
@@ -798,6 +794,7 @@ const createAssets = async (packagePath: any, destination_stack_id: string, proj
       );
 
       await Promise.all(tasks);
+      await fs.promises.mkdir(assetsSave, { recursive: true });
       const assetMasterFolderPath = path.join(assetsSave, ASSETS_FAILED_FILE);
 
       await writeOneFile(path.join(assetsSave, ASSETS_SCHEMA_FILE), assetData);


### PR DESCRIPTION
## 🔗 Jira Ticket

[CMG-1093 — Delta migration | v1.0.0 | Contentful migration got stuck some time](https://contentstack.atlassian.net/browse/CMG-1093)

---

## 📋 PR Type

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

- `writeOneFile` now uses `fs.promises.writeFile` and is properly awaited. It was previously calling the callback-based `fs.writeFile` in a fire-and-forget pattern, so the outer `await writeOneFile(...)` returned before the file was actually written to disk.
- In `createAssets`, added `fs.promises.mkdir(assetsSave, { recursive: true })` before writing the assets schema/failed files, so the destination directory is guaranteed to exist.

### Why?

During delta Contentful migrations the process would occasionally hang or leave a partial state. Root cause: the assets step kicked off a non-awaited write and moved on, and if the `assetsSave` directory did not yet exist the callback error was swallowed via `console.error`, leaving downstream steps waiting on a file that was never written. Both issues are fixed here.

---

## 🧩 Affected Areas

- [x] `api` — Node.js backend
- [ ] `ui` — React frontend
- [ ] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

1. Run a Contentful delta migration on a project that produced the hang in v1.0.0 (any project with assets works).
2. Watch the API logs and the `assets/` output directory as the assets step runs.
3. Confirm the migration proceeds past the assets step without stalling, and that `assets/<project>/assets.json` (and the failed-assets file, if any) are written before the next step begins.

**Expected result:** Migration completes end-to-end; the assets directory is created if missing, `assets.json` is fully written before subsequent steps run, and no `Error writing file: 3` messages appear in logs.

---

## 📸 Screenshots / Recordings

N/A — backend-only fix, no UI changes.

---

## 🔗 Related PRs / Dependencies

- None

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `bugfix/cmg-1093-contentful-migration-issue`
- [x] Jira ticket linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added — N/A
- [x] No sensitive credentials or secrets committed
- [ ] Existing tests pass locally (`npm test`)
- [ ] New tests written (or not applicable — no unit test exists for this file path and the fix is a race-condition/IO ordering change best verified via the manual repro above)
- [ ] `README.md` / docs updated if behaviour changed — N/A
- [ ] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

Please focus on:
- The `writeOneFile` change — confirm no other caller relies on the previous non-awaiting behaviour (`grep` shows all call sites already `await` it).
- The `mkdir` placement in `createAssets` — it runs after `Promise.all(tasks)` and before the first `writeOneFile` in that block, so both the schema file and the failed-assets file land in an existing directory.