### PR TITLE
CMG-1094/1095/1096/1097 | Delta Map Entry UI fixes: asset URL overflow, CT list 

### DIFF
--- a/ui/src/components/ContentMapper/assetMapper.tsx
+++ b/ui/src/components/ContentMapper/assetMapper.tsx
@@ -320,7 +320,6 @@ const AssetMapper = ({
                 heading={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_HEADING}
                 description={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_DESCRIPTION}
                 moduleIcon={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_ICON}
-                type="secondary"
                 className="custom-empty-state"
               />
             }

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -673,7 +673,6 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
                       heading={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_HEADING}
                       description={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_DESCRIPTION}
                       moduleIcon={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_ICON}
-                      type="secondary"
                       className="custom-empty-state"
                     />
                   }

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -53,8 +53,51 @@
     }
   }
 }
+// Both ContentMapper (.table-wrapper) and AssetMapper (.asset-mapper-table)
+// render venus's <Table>. Venus's own CSS sets
+// `.Table__body__column { min-width: auto !important; width: auto !important }`,
+// which overrides every column-width we configure and lets an unbreakable URL
+// expand the cell past its share, bleeding text over the next columns. Force
+// min-width: 0 on the cell so it can shrink to its flex-basis and the child
+// (.cms-field--wrap) can wrap character-by-character.
+.table-wrapper .Table__body__column,
+.asset-mapper-table .Table__body__column {
+  min-width: 0 !important;
+}
+.table-wrapper .Table__body__column .d-flex,
+.asset-mapper-table .Table__body__column .d-flex {
+  min-width: 0;
+}
+// The wrap styling itself was only defined inside `.table-wrapper .Table`,
+// so AssetMapper's `.cms-field--wrap` cells got no wrap rules. Duplicate the
+// wrap rules under `.asset-mapper-table` so long URLs actually break there.
+.asset-mapper-table .cms-field {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.asset-mapper-table .cms-field--wrap {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  -webkit-line-clamp: unset;
+  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
 .ct-list-wrapper {
-  height: calc(100vh - 375px);
+  // The wrapper's bottom must stay inside the viewport, else its internal
+  // scroll ends off-screen and the last few items become unreachable.
+  // Measured wrapper-top on the delta Map Entry step is ~490px (migration
+  // header + horizontal 6-step stepper + tabs + list header + search),
+  // leaving ~viewport - 490 for a fully-visible scroll region. 500px
+  // (10px buffer) keeps the wrapper inside the viewport across sizes.
+  height: calc(100vh - 500px);
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -198,15 +241,18 @@
     }
     // Asset mapper: long filenames/paths should wrap within their own column
     // instead of clamping to one line and bleeding into the next column.
+    // Unbreakable URLs made the flex cell expand past the column width — pin the
+    // wrapper to the parent's width and force per-character breaks.
     .cms-field--wrap {
       display: block;
       width: 100%;
       max-width: 100%;
+      min-width: 0;
       -webkit-line-clamp: unset;
-      overflow: visible;
+      overflow: hidden;
       white-space: normal;
       overflow-wrap: anywhere;
-      word-break: break-word;
+      word-break: break-all;
     }
     .InstructionText {
       font-size: $size-font-small;
@@ -505,6 +551,15 @@ div .table-row {
 
 
 .custom-empty-state {
+  // Force the empty state to occupy the body area instead of collapsing into
+  // (and overlapping) the table header when the search returns zero rows.
+  min-height: 300px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+
   .Icon--original {
     width: 207px !important;
     height: auto !important;

--- a/ui/src/components/ContentMapper/index.tsx
+++ b/ui/src/components/ContentMapper/index.tsx
@@ -3476,7 +3476,6 @@ const ContentMapper = forwardRef(({ handleStepChange }: contentMapperProps, ref:
                       heading={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_HEADING}
                       description={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_DESCRIPTION}
                       moduleIcon={MAPPER_SEARCH_EMPTY_STATE.NO_MATCH_ICON}
-                      type="secondary"
                       className="custom-empty-state"
                     />
                   }


### PR DESCRIPTION
## 🔗 Jira Tickets
Parent story: [CMG-789 — Delta Migration | v1.0.0 | Update Feature Implementation](https://contentstack.atlassian.net/browse/CMG-789)

- [CMG-1094 — Contentful: Assets URLs are overlapped](https://contentstack.atlassian.net/browse/CMG-1094)
- [CMG-1095 — Delta iter 2+: not all content types are displayed on Map Entry](https://contentstack.atlassian.net/browse/CMG-1095)
- [CMG-1096 — Delta Migration | v1.0.0 | Save button gets cut off on the map entries field.](https://contentstack.atlassian.net/browse/CMG-1096)

- [CMG-1097 — Assets screen: empty-state / error message not displayed properly](https://contentstack.atlassian.net/browse/CMG-1097)

---

## 📋 PR Type

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / Dependency Update
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

- **CMG-1094 — Asset Path URLs no longer bleed into Size / Contentstack UIDs columns.** Venus's own CSS forces `.Table__body__column { min-width: auto !important; width: auto !important }`, so every column width we configured was being ignored and an unbreakable URL expanded the Path cell over its neighbours. Added a top-level override (`.table-wrapper .Table__body__column, .asset-mapper-table .Table__body__column { min-width: 0 !important }`) so the cell can shrink to its flex-basis, and duplicated the `.cms-field` / `.cms-field--wrap` wrap rules under `.asset-mapper-table` (they previously only existed under `.table-wrapper`, so AssetMapper never got them). `.cms-field--wrap` now uses `overflow: hidden`, `min-width: 0`, `overflow-wrap: anywhere`, and `word-break: break-all` so URL text breaks character-by-character inside its column.
- **CMG-1095 — Last few content types on the Map Entry step are now reachable.** `.ct-list-wrapper` had `height: calc(100vh - 375px)`, tuned for the Map Content Fields step. Delta iterations render a 6-step horizontal stepper (vs 5) plus the Entries/Assets tab bar, pushing the wrapper's top down to ~490px. The wrapper's bottom then sat below the viewport, so the internal `overflow-y: auto` scroll ended off-screen and the last rows couldn't be reached. Changed to `height: calc(100vh - 500px)` so the wrapper's bottom stays ~10px above the viewport edge and the scroll region is fully visible.
- **CMG-1097 — Search empty-state renders below the column header, with heading and description.** Removed `type="secondary"` from the three `customEmptyState` blocks (`assetMapper.tsx`, `entryMapper.tsx`, `ContentMapper/index.tsx`) — `secondary` was rendering just the icon and hiding the heading/description. Added `min-height: 300px` + centred flex layout to `.custom-empty-state` so the empty area occupies the body instead of collapsing into (and overlapping) the header row.

### Why?

Three UI regressions filed against Delta Migration v1.0.0 (all subtasks of CMG-789). Two are pure CSS regressions caused by venus overrides / hard-coded viewport offsets that no longer match the delta layout; one is a wrong-prop on venus's `EmptyState`. Grouping them because they all live in `ui/src/components/ContentMapper/*` and share the same review context.

CMG-1096 (Save button cut off on Map Entries) is **not** included — I couldn't reproduce the clip from the shared screenshots. It will be handled in a follow-up once repro steps are confirmed.

---

## 🧩 Affected Areas

- [ ] `api` — Node.js backend
- [x] `ui` — React frontend
- [ ] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other:

---

## 🧪 How to Test

Complete an initial migration on a Contentful project (any project with ≥15 content types and ≥5 assets), then click **Restart Migration** to enter delta iteration 2 and land on **Map Entry (step 4)**.

**CMG-1094 — Asset URL overflow**
1. Open the **Assets** tab on Map Entry.
2. Confirm each row's Path URL wraps/truncates inside its own column — no text bleeding into the Size or Contentstack UIDs columns.

**CMG-1095 — Content types list scroll**
1. On the **Entries** tab, view the **Content Models** panel on the left.
2. Scroll the list — confirm every content type (all N of N) is reachable, including the last 3-4 that were previously off-screen.

**CMG-1097 — Empty-state on search**
1. On the **Assets** tab, type a query that returns no matches (e.g. `qwerf`).
2. Confirm the empty-state renders in the body area with the illustration + "No matching result found" heading + description — not overlapping the column-header row.

**Expected result:** All three defects resolved on the delta Map Entry step, and no regression on the initial (iter-1) Map Content Fields step.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
| Path URLs overlap Size / Contentstack UIDs columns (see CMG-1094) | Each URL constrained to its column, wraps within cell |
| Only ~8 of 19 content types visible; scroll bar unreachable (see CMG-1095) | All 19 accessible via internal scroll on the list |
| Empty-state icon rendered on top of column headers, no text (see CMG-1097) | Illustration + heading + description render inside the body area |

---

## 🔗 Related PRs / Dependencies

- Parent story: [CMG-789](https://contentstack.atlassian.net/browse/CMG-789)
- Sibling ticket not addressed here: [CMG-1096 — Save button cut off on Map Entries](https://contentstack.atlassian.net/browse/CMG-1096) (pending repro; separate PR)

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `bugfix/cmg-1094-97-delta-ui`
- [x] Jira tickets linked above
- [x] Self-reviewed the diff — no debug logs, commented-out code, or TODOs left in
- [ ] `.env` / `example.env` updated if new environment variables were added — N/A
- [x] No sensitive credentials or secrets committed
- [ ] Existing tests pass locally (`npm test`)
- [ ] New tests written (or not applicable — CSS-only changes and one venus prop removal; no unit-test surface. UI verified manually per the steps above)
- [ ] `README.md` / docs updated if behaviour changed — N/A
- [ ] Talisman pre-push scan passes (no secrets flagged)

---

## 👀 Reviewer Notes

- The `!important` on `.Table__body__column { min-width: 0 !important }` is required to beat venus's own `!important` on the same property. It's scoped to `.table-wrapper` and `.asset-mapper-table` only, so it doesn't leak to other venus tables in the app.
- CMG-1095's fix is a viewport-height calc (`100vh - 500px`) tuned against a measured wrapper-top of ~490px on the delta Map Entry step. If the header stack above the wrapper changes materially (extra tab bars, taller stepper), this constant would need re-tuning — a follow-up to switch to a JS-measured height (like `useMeasuredTableHeight` used for the entry table) would remove the constant entirely, but felt out-of-scope for a bug fix.
- No changes outside `ui/src/components/ContentMapper/`.