### PR TITLE
chore(deps): bump fast-uri and brace-expansion overrides to clear Snyk SLA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -570,15 +570,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/breakword": {
@@ -1454,9 +1454,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.0.0.tgz",
-      "integrity": "sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "@tootallnate/once": ">=3.0.1",
     "fast-xml-parser": ">=5.3.8",
     "diff": ">=5.2.2",
-    "fast-uri": ">=3.1.2",
-    "brace-expansion": ">=5.0.6"
+    "fast-uri": ">=4.1.1",
+    "brace-expansion": ">=5.0.9"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Bumps the root overrides for two transitive deps that just crossed the 30-day Snyk SLA and are blocking every PR opened against dev.

- `fast-uri`: `>=3.1.2` → `>=4.1.1` (SNYK-JS-FASTURI-17675102, CVSS 8.7)
- `brace-expansion`: `>=5.0.6` → `>=5.0.9` (SNYK-JS-BRACEEXPANSION-17706650, CVSS 8.7)

Only `package.json` + `package-lock.json` change. No app code touched. Merge this before #1128 (CMG-1101) so its Snyk check re-runs green.