### PR TITLE
Bugfix(delta) | References, Entry Mapping, RTE, empty-state, CT count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -373,3 +373,6 @@ app.json
 # Test coverage (global)
 coverage/
 export-stack/
+allien/
+aem_data_structure/
+.claude/

--- a/api/src/controllers/projects.contentMapper.controller.ts
+++ b/api/src/controllers/projects.contentMapper.controller.ts
@@ -212,6 +212,18 @@ const updateAssetStatus = async (req: Request, res: Response): Promise<void> => 
   res.status(resp?.status).json(resp);
 };
 
+/**
+ * Re-attempts the download for one asset that failed during the last migration run.
+ *
+ * @param req - The request object.
+ * @param res - The response object.
+ * @returns A Promise that resolves to void.
+ */
+const retryAssetDownload = async (req: Request, res: Response): Promise<void> => {
+  const resp = await contentMapperService.retryAssetDownload(req);
+  res.status(resp?.status).json(resp);
+};
+
 export const contentMapperController = {
   getContentTypes,
   getFieldMapping,
@@ -229,5 +241,6 @@ export const contentMapperController = {
   getEntryMapping,
   updateEntryStatus,
   getAssetMapping,
-  updateAssetStatus
+  updateAssetStatus,
+  retryAssetDownload
 };

--- a/api/src/routes/contentMapper.routes.ts
+++ b/api/src/routes/contentMapper.routes.ts
@@ -137,6 +137,15 @@ router.put(
 );
 
 /**
+ * Retry downloading a single asset that failed during the last migration run
+ * @route PUT /retryAsset/:projectId/:assetUid
+ */
+router.put(
+  "/retryAsset/:projectId/:assetUid",
+  asyncRouter(contentMapperController.retryAssetDownload)
+);
+
+/**
  * Get Single Global Field data
  * @route GET /:projectId/:globalFieldUid
  */

--- a/api/src/services/contentMapper.service.ts
+++ b/api/src/services/contentMapper.service.ts
@@ -15,6 +15,7 @@ import {
   CONTENT_TYPE_STATUS,
   VALIDATION_ERRORS,
   MIGRATION_DATA_CONFIG,
+  CMS,
 } from '../constants/index.js';
 import logger from '../utils/logger.js';
 import { config } from '../config/index.js';
@@ -35,6 +36,7 @@ import { isDuplicateEntry } from '../utils/entry-duplicate.utils.js';
 import { getSourceLocaleForDestination } from '../utils/locale-migration.utils.js';
 import { loadPreviousAssetMetadata } from '../utils/asset-update.utils.js';
 import { flattenNestedUidMap } from '../utils/uid-mapper.utils.js';
+import { contentfulService } from './contentful.service.js';
 
 
 const idCorrector = ({ id }: { id: string }) => {
@@ -176,11 +178,7 @@ const putTestData = async (req: Request) => {
 
     const uidMapperCurrent = getUidMapperDb(projectId, iteration);
     await uidMapperCurrent.read();
-    let uidMapperPrev: any = null;
-    if (iteration > 1) {
-      uidMapperPrev = getUidMapperDb(projectId, iteration - 1);
-      await uidMapperPrev.read();
-    }
+    const uidMapperPrev: any = iteration > 1 ? await getNearestPriorUidMapper(projectId, iteration) : null;
 
     const mergeEntry = (base: any, incoming: any) => {
       const keep = { ...(base ?? {}) };
@@ -2009,24 +2007,40 @@ const updateEntryStatus = async (req: Request) => {
       .find({ id: projectId })
       .value();
     const iteration = projectData?.iteration || 1;
-    const EntryMapperModel = getEntryMapperDb(projectId, iteration);
-    await EntryMapperModel.read();
-    const foundEntry: EntryMapper[] = [];
     // Rows in entry_mapper are per-(entry × source-locale); each id is unique per row.
     // Also scope the toggle by source-locale as a safety net so a same-id collision
     // (if it ever happens) can't flip a sibling locale's row and clobber the user's
-    // selection state on the other locale.
+    // selection state on the other locale. Only enforced when the row actually carries
+    // a language — legacy rows created before language-tagging existed have none, and
+    // requiring a match against them would make them permanently untoggleable.
     const sourceLocale = locale
       ? getSourceLocaleForDestination(projectData ?? {}, locale)
       : null;
-    await EntryMapperModel.update((data: any) => {
-      data?.entry_mapper?.forEach((entry: any) => {
-        if (!validatedUids.includes(entry?.id)) return;
-        if (sourceLocale && (entry?.language ?? '') !== sourceLocale) return;
-        entry.isUpdate = !entry.isUpdate;
-        foundEntry.push(entry);
+
+    const toggleInModel = async (iter: number): Promise<EntryMapper[]> => {
+      const model = getEntryMapperDb(projectId, iter);
+      await model.read();
+      const matched: EntryMapper[] = [];
+      await model.update((data: any) => {
+        data?.entry_mapper?.forEach((entry: any) => {
+          if (!validatedUids.includes(entry?.id)) return;
+          if (sourceLocale && entry?.language && entry.language !== sourceLocale) return;
+          entry.isUpdate = !entry.isUpdate;
+          matched.push(entry);
+        });
       });
-    });
+      return matched;
+    };
+
+    let foundEntry = await toggleInModel(iteration);
+
+    // Fallback: mirrors getEntryMapping's read-side fallback (contentMapper.service.ts
+    // ~2119-2131) — right after a restart, before iteration N's entry-mapper rows exist,
+    // Map Entry renders rows sourced from iteration N-1. Without this, saving those rows
+    // 404s here even though the user is looking at exactly what the read path showed them.
+    if (!foundEntry.length && iteration > 1) {
+      foundEntry = await toggleInModel(iteration - 1);
+    }
 
     if (foundEntry.length) {
       return {
@@ -2223,6 +2237,29 @@ const lookupContentstackEntryUidFromUidMap = (
   return String(resolved).trim() || undefined;
 };
 
+/**
+ * Loads the nearest prior iteration's uid-mapper model, walking backward from
+ * `iteration - 1` down to 1 — not just `iteration - 1` alone. `writeUidMapping` already
+ * merges each successful run's uid-mapper.json forward from the one before it, so the
+ * nearest prior iteration that actually has a file already carries everything from every
+ * iteration before it; we only need to skip iterations where the file is simply absent
+ * (e.g. a restart that skipped an actual "Start Migration" run for that iteration — see
+ * CMG-1095, the same gap for content types). Without this, a single skipped iteration
+ * permanently breaks uid resolution for every iteration after it.
+ */
+const getNearestPriorUidMapper = async (projectId: string, iteration: number): Promise<any | null> => {
+  for (let i = iteration - 1; i >= 1; i--) {
+    const model = getUidMapperDb(projectId, i);
+    await model.read();
+    const data = model?.data as any;
+    const hasData =
+      Object.keys(data?.entry ?? {}).length > 0 ||
+      Object.keys(data?.assets ?? {}).length > 0;
+    if (hasData) return model;
+  }
+  return null;
+};
+
 const getEntryUidMap = (uidMapperModel: any): Record<string, any> => {
   const d = uidMapperModel?.data ?? {};
   const pick = (x: unknown): Record<string, any> => {
@@ -2256,11 +2293,7 @@ const enrichEntriesWithUidMapper = async (
   const currentModel = getUidMapperDb(projectId, iteration);
   await currentModel.read();
 
-  let prevModel: any = null;
-  if (iteration > 1) {
-    prevModel = getUidMapperDb(projectId, iteration - 1);
-    await prevModel.read();
-  }
+  const prevModel: any = iteration > 1 ? await getNearestPriorUidMapper(projectId, iteration) : null;
 
   return entries?.map((item: any) => {
     if (!item) return item;
@@ -2347,12 +2380,83 @@ const updateAssetStatus = async (req: Request) => {
   }
 };
 
+/**
+ * Re-attempts the download for one asset that failed during the last migration run
+ * (currently CMS Contentful only — the `cs_failed.json` file this reads is written by
+ * contentfulService.createAssets). Only re-stages the asset locally; it lands in the
+ * destination stack on the next migration run (Start Migration), same as any other asset.
+ */
+const retryAssetDownload = async (req: Request) => {
+  const srcFunc = "retryAssetDownload";
+  const projectId = req?.params?.projectId;
+  const assetUid = req?.params?.assetUid;
+
+  if (!assetUid) {
+    return {
+      status: HTTP_CODES?.BAD_REQUEST,
+      data: { message: "Missing assetUid" },
+    };
+  }
+
+  try {
+    await ProjectModelLowdb.read();
+    const projectData: any = ProjectModelLowdb.chain
+      .get("projects")
+      .find({ id: projectId })
+      .value();
+
+    const destinationStackId = projectData?.destination_stack_id;
+    const filePath = projectData?.legacy_cms?.file_path;
+    const cms = projectData?.legacy_cms?.cms;
+
+    if (!destinationStackId || !filePath) {
+      return {
+        status: HTTP_CODES?.BAD_REQUEST,
+        data: { message: "Project is missing a destination stack or source file path." },
+      };
+    }
+    if (cms !== CMS.CONTENTFUL) {
+      return {
+        status: HTTP_CODES?.BAD_REQUEST,
+        data: { message: "Asset retry is only supported for Contentful projects." },
+      };
+    }
+
+    const cleanLocalPath = filePath.replace(/\/$/, '');
+    const result = await contentfulService.retryFailedAsset(
+      cleanLocalPath,
+      destinationStackId,
+      projectId,
+      assetUid,
+    );
+
+    return {
+      status: result.success ? HTTP_CODES?.OK : HTTP_CODES?.BAD_REQUEST,
+      data: result,
+    };
+  } catch (error: any) {
+    logger.error(
+      getLogMessage(
+        srcFunc,
+        "Error occurred while retrying asset download",
+        error
+      )
+    );
+    throw new ExceptionFunction(
+      error?.message || HTTP_TEXTS.INTERNAL_ERROR,
+      error?.statusCode || error?.status || HTTP_CODES.SERVER_ERROR,
+    );
+  }
+};
+
 const getAssetMapping = async (req: Request) => {
   const srcFunc = "getAssetMapping";
   const projectId = req?.params?.projectId;
   const skip: any = req?.params?.skip;
   const limit: any = req?.params?.limit;
   const search: string = req?.params?.searchText?.toLowerCase();
+  // Optional status filter: ?status=failed | missing | ok. Absent/anything else = no filter.
+  const statusFilter = req?.query?.status as string | undefined;
 
   let result: any[] = [];
   let filteredResult = [];
@@ -2385,15 +2489,27 @@ const getAssetMapping = async (req: Request) => {
     }
 
     // Fill missing contentstackAssetUid from uid-mapper (current first, then
-    // the previous iteration) so rows saved before the import resolve later.
+    // the nearest prior iteration that actually has one) so rows saved before
+    // the import resolve later.
     const uidMapperCurrent = getUidMapperDb(projectId, iteration);
     await uidMapperCurrent.read();
-    let uidMapperPrev: any = null;
-    if (iteration > 1) {
-      uidMapperPrev = getUidMapperDb(projectId, iteration - 1);
-      await uidMapperPrev.read();
-    }
-    const enrichedMapping = (assetMapping ?? []).map((item: any) => {
+    const uidMapperPrev: any = iteration > 1 ? await getNearestPriorUidMapper(projectId, iteration) : null;
+
+    // Whether we actually have any uid data to resolve against yet. getUidMapperDb creates
+    // the file with an empty `assets: {}` default, so a fresh iteration directory (visited
+    // right after a restart, before this iteration's CLI import has run and written
+    // writeUidMapping's output) legitimately has none — distinct from "this project simply
+    // has no previously-migrated assets". Also true if any row already carries a
+    // pre-resolved uid from creation time (putTestData resolves it then, see ~line 280).
+    const hasAnyUidData =
+      Object.keys((uidMapperCurrent?.data as any)?.assets ?? {}).length > 0 ||
+      Object.keys((uidMapperPrev?.data as any)?.assets ?? {}).length > 0 ||
+      (assetMapping ?? []).some((item: any) => {
+        const uid = item?.contentstackAssetUid;
+        return uid != null && String(uid).trim() !== '';
+      });
+
+    let uidEnriched = (assetMapping ?? []).map((item: any) => {
       if (!item) return item;
       const existing = item?.contentstackAssetUid;
       if (existing != null && String(existing).trim() !== '') {
@@ -2405,36 +2521,86 @@ const getAssetMapping = async (req: Request) => {
       return resolved ? { ...item, contentstackAssetUid: resolved } : item;
     });
 
+    // Status per row for the UI: 'missing' (no url/upload in the source at all — nothing
+    // to retry), 'failed' (had a source but the last migration run's download attempt
+    // threw — retriable), or 'ok'. Read once per request; cs_failed.json is only written
+    // after an actual migration run, so it's absent (empty status) before that.
+    let failedAssets: Record<string, any> = {};
+    const destinationStackId = projectData?.destination_stack_id;
+    if (destinationStackId) {
+      const failedPath = path.join(MIGRATION_DATA_CONFIG.DATA, destinationStackId, MIGRATION_DATA_CONFIG.ASSETS_DIR_NAME, MIGRATION_DATA_CONFIG.ASSETS_FAILED_FILE);
+      if (fs.existsSync(failedPath)) {
+        try {
+          failedAssets = JSON.parse(fs.readFileSync(failedPath, 'utf-8')) || {};
+        } catch {
+          failedAssets = {};
+        }
+      }
+    }
+    const enrichedMapping = uidEnriched.map((item: any) => {
+      if (!item) return item;
+      if (item?.hasSource === false) {
+        return { ...item, status: 'missing', errorMessage: 'No source file found for this asset — nothing to migrate.' };
+      }
+      const failure = failedAssets?.[item?.otherCmsAssetUid];
+      if (failure) {
+        return { ...item, status: 'failed', errorMessage: failure?.reason_for_error || 'Failed to download this asset during the last migration run.' };
+      }
+      return { ...item, status: 'ok' };
+    });
+
     // Delta migration intent: on iteration 2+ the Assets tab lists ONLY assets that
     // were already migrated in a prior iteration — i.e. those with a Contentstack
     // uid. The user selects which of those to update with the current file's newer
     // version. Brand-new assets in this iteration have no prior uid; they upload
     // automatically during the run and don't need a Map Entry row (nothing to
     // select or update yet). Iteration 1 is untouched — everything is new then.
-    const displayMapping = iteration > 1
+    //
+    // Exception: always surface 'failed'/'missing' rows even without a uid. A brand-new
+    // asset that fails to download NEVER gets a Contentstack uid (it never successfully
+    // migrates), so the has-uid check alone would hide it from view forever — the user
+    // would have no way to discover or retry it.
+    // Only apply the delta filter once we actually have uid data to filter with —
+    // otherwise a race right after restart (this iteration's uid-mapper.json not written
+    // yet) would filter out EVERY row and render an empty tab indistinguishable from "no
+    // previously-migrated assets", which could be mistaken for correct behavior since
+    // CMG-1097 already gives that empty state a legitimate-looking layout.
+    const displayMapping = iteration > 1 && hasAnyUidData
       ? enrichedMapping.filter((item: any) => {
           const uid = item?.contentstackAssetUid;
-          return uid != null && String(uid).trim() !== '';
+          const hasUid = uid != null && String(uid).trim() !== '';
+          return hasUid || item?.status === 'failed' || item?.status === 'missing';
         })
       : enrichedMapping;
 
-    if (!isEmpty(displayMapping)) {
+    // Aggregate counts across the FULL (unpaginated, unsearched) visible set — the banner
+    // needs "3 assets won't migrate" regardless of which page or search term is active.
+    const missingCount = displayMapping.filter((item: any) => item?.status === 'missing').length;
+    const failedCount = displayMapping.filter((item: any) => item?.status === 'failed').length;
+
+    const statusFiltered = statusFilter && ['ok', 'missing', 'failed'].includes(statusFilter)
+      ? displayMapping.filter((item: any) => item?.status === statusFilter)
+      : displayMapping;
+
+    if (!isEmpty(statusFiltered)) {
       if (search) {
-        filteredResult = displayMapping?.filter?.((item: any) =>
+        filteredResult = statusFiltered?.filter?.((item: any) =>
           item?.filename?.toLowerCase().includes(search) ||
           item?.title?.toLowerCase().includes(search)
         );
         totalCount = filteredResult?.length;
         result = filteredResult?.slice(skip, Number(skip) + Number(limit));
       } else {
-        totalCount = displayMapping?.length;
-        result = displayMapping?.slice(skip, Number(skip) + Number(limit));
+        totalCount = statusFiltered?.length;
+        result = statusFiltered?.slice(skip, Number(skip) + Number(limit));
       }
     }
     return {
       status: HTTP_CODES?.OK,
       count: totalCount,
-      assetMapping: result
+      assetMapping: result,
+      missingCount,
+      failedCount,
     };
 
   } catch (error: any) {
@@ -2473,4 +2639,5 @@ export const contentMapperService = {
   updateEntryStatus,
   getAssetMapping,
   updateAssetStatus,
+  retryAssetDownload,
 };

--- a/api/src/services/contentMapper.service.ts
+++ b/api/src/services/contentMapper.service.ts
@@ -2028,7 +2028,7 @@ const updateEntryStatus = async (req: Request) => {
       });
     });
 
-    if (foundEntry) {
+    if (foundEntry.length) {
       return {
         status: HTTP_CODES?.OK,
         data: foundEntry

--- a/api/src/services/contentMapper.service.ts
+++ b/api/src/services/contentMapper.service.ts
@@ -2405,17 +2405,30 @@ const getAssetMapping = async (req: Request) => {
       return resolved ? { ...item, contentstackAssetUid: resolved } : item;
     });
 
-    if (!isEmpty(enrichedMapping)) {
+    // Delta migration intent: on iteration 2+ the Assets tab lists ONLY assets that
+    // were already migrated in a prior iteration — i.e. those with a Contentstack
+    // uid. The user selects which of those to update with the current file's newer
+    // version. Brand-new assets in this iteration have no prior uid; they upload
+    // automatically during the run and don't need a Map Entry row (nothing to
+    // select or update yet). Iteration 1 is untouched — everything is new then.
+    const displayMapping = iteration > 1
+      ? enrichedMapping.filter((item: any) => {
+          const uid = item?.contentstackAssetUid;
+          return uid != null && String(uid).trim() !== '';
+        })
+      : enrichedMapping;
+
+    if (!isEmpty(displayMapping)) {
       if (search) {
-        filteredResult = enrichedMapping?.filter?.((item: any) =>
+        filteredResult = displayMapping?.filter?.((item: any) =>
           item?.filename?.toLowerCase().includes(search) ||
           item?.title?.toLowerCase().includes(search)
         );
         totalCount = filteredResult?.length;
         result = filteredResult?.slice(skip, Number(skip) + Number(limit));
       } else {
-        totalCount = enrichedMapping?.length;
-        result = enrichedMapping?.slice(skip, Number(skip) + Number(limit));
+        totalCount = displayMapping?.length;
+        result = displayMapping?.slice(skip, Number(skip) + Number(limit));
       }
     }
     return {

--- a/api/src/services/contentMapper.service.ts
+++ b/api/src/services/contentMapper.service.ts
@@ -34,6 +34,7 @@ import getUidMapperDb from "../models/uidMapper.js";
 import { isDuplicateEntry } from '../utils/entry-duplicate.utils.js';
 import { getSourceLocaleForDestination } from '../utils/locale-migration.utils.js';
 import { loadPreviousAssetMetadata } from '../utils/asset-update.utils.js';
+import { flattenNestedUidMap } from '../utils/uid-mapper.utils.js';
 
 
 const idCorrector = ({ id }: { id: string }) => {
@@ -2219,17 +2220,6 @@ const getEntryUidMap = (uidMapperModel: any): Record<string, any> => {
   if (nUid > 0) return fromEntryUid;
   if (nEnt > 0) return fromEntry;
   return {};
-};
-
-const flattenNestedUidMap = (raw: Record<string, any>): Record<string, any> => {
-  const keys = Object?.keys(raw ?? {});
-  if (keys?.length === 0) return {};
-  const nested = keys?.every((k) => {
-    const v = raw[k];
-    return v != null && typeof v === 'object' && !Array.isArray(v);
-  });
-  if (!nested) return { ...raw };
-  return keys.reduce<Record<string, any>>((acc, k) => ({ ...acc, ...raw[k] }), {});
 };
 
 /**

--- a/api/src/services/contentMapper.service.ts
+++ b/api/src/services/contentMapper.service.ts
@@ -469,15 +469,29 @@ const getContentTypes = async (req: Request) => {
     );
 
     // Delta migration: from iteration 2 onwards, split content types into new vs old
-    // relative to the previous iteration so Step 3 (field mapping) shows only new types
-    // and Step 4 (entry mapping) shows only already-migrated types. Iteration 1 is untouched.
+    // relative to EVERY prior iteration (1..N-1) so Step 3 (field mapping) shows only
+    // genuinely-never-seen types and Step 4 (entry mapping) shows every already-migrated
+    // type. Comparing only against iteration N-1 misclassified any content type that
+    // was migrated in iteration 1 but absent from the iteration-2 source as "new" on
+    // iteration 3 — sending already-migrated types back to Map Content Fields and
+    // hiding them from Map Entry. Iteration 1 is untouched.
     if (iteration > 1) {
-      const PrevContentTypesMapperModelLowdb = getContentTypesMapperDb(projectId, iteration - 1);
-      await PrevContentTypesMapperModelLowdb.read();
-      const prevContentMapper =
-        PrevContentTypesMapperModelLowdb.chain.get('ContentTypesMappers').value() ?? [];
+      const seenPrevCts: ContentTypesMapper[] = [];
+      const seenPrevUids = new Set<string>();
+      for (let i = 1; i < iteration; i++) {
+        const priorModel = getContentTypesMapperDb(projectId, i);
+        await priorModel.read();
+        const cts = priorModel.chain.get('ContentTypesMappers').value() ?? [];
+        for (const ct of cts) {
+          const uid = ct?.otherCmsUid;
+          if (uid && !seenPrevUids.has(uid)) {
+            seenPrevUids.add(uid);
+            seenPrevCts.push(ct);
+          }
+        }
+      }
 
-      const filtered = filterContentTypesByIteration(content_mapper, prevContentMapper, filter);
+      const filtered = filterContentTypesByIteration(content_mapper, seenPrevCts, filter);
       content_mapper.length = 0;
       content_mapper.push(...filtered);
 
@@ -1971,7 +1985,7 @@ const getExistingExtensions = async ({existingStackId, token_payload}: any) => {
 
 const updateEntryStatus = async (req: Request) => {
   const { projectId } = req?.params;
-  const { ids } = req?.body;
+  const { ids, locale } = req?.body;
   const validatedUids: string[] = Array.isArray(ids) ? ids : [];
   const srcFunc = "updateEntryMapping";
   if (isEmpty(validatedUids)) {
@@ -1998,14 +2012,19 @@ const updateEntryStatus = async (req: Request) => {
     const EntryMapperModel = getEntryMapperDb(projectId, iteration);
     await EntryMapperModel.read();
     const foundEntry: EntryMapper[] = [];
-    // Rows in entry_mapper are already per-(entry × source-locale), so each id uniquely
-    // identifies one locale variant; toggling isUpdate directly is correct.
+    // Rows in entry_mapper are per-(entry × source-locale); each id is unique per row.
+    // Also scope the toggle by source-locale as a safety net so a same-id collision
+    // (if it ever happens) can't flip a sibling locale's row and clobber the user's
+    // selection state on the other locale.
+    const sourceLocale = locale
+      ? getSourceLocaleForDestination(projectData ?? {}, locale)
+      : null;
     await EntryMapperModel.update((data: any) => {
       data?.entry_mapper?.forEach((entry: any) => {
-        if (validatedUids.includes(entry?.id)) {
-          entry.isUpdate = !entry.isUpdate;
-          foundEntry.push(entry);
-        }
+        if (!validatedUids.includes(entry?.id)) return;
+        if (sourceLocale && (entry?.language ?? '') !== sourceLocale) return;
+        entry.isUpdate = !entry.isUpdate;
+        foundEntry.push(entry);
       });
     });
 

--- a/api/src/services/contentMapper.service.ts
+++ b/api/src/services/contentMapper.service.ts
@@ -37,6 +37,7 @@ import { getSourceLocaleForDestination } from '../utils/locale-migration.utils.j
 import { loadPreviousAssetMetadata } from '../utils/asset-update.utils.js';
 import { flattenNestedUidMap } from '../utils/uid-mapper.utils.js';
 import { contentfulService } from './contentful.service.js';
+import { sanitizeStackId, assertResolvedPathUnderBase } from '../utils/sanitize-path.utils.js';
 
 
 const idCorrector = ({ id }: { id: string }) => {
@@ -2527,14 +2528,22 @@ const getAssetMapping = async (req: Request) => {
     // after an actual migration run, so it's absent (empty status) before that.
     let failedAssets: Record<string, any> = {};
     const destinationStackId = projectData?.destination_stack_id;
-    if (destinationStackId) {
-      const failedPath = path.join(MIGRATION_DATA_CONFIG.DATA, destinationStackId, MIGRATION_DATA_CONFIG.ASSETS_DIR_NAME, MIGRATION_DATA_CONFIG.ASSETS_FAILED_FILE);
-      if (fs.existsSync(failedPath)) {
-        try {
+    // destination_stack_id is DB-stored, but Snyk's taint tracker still traces it back to
+    // the HTTP projectId param via the lowdb lookup above — sanitize it the same way the
+    // rest of this codebase does (sanitizeStackId strips it to an allowlisted charset,
+    // assertResolvedPathUnderBase re-confirms the joined path can't escape the data dir)
+    // before it reaches a readFileSync sink.
+    const safeDestinationStackId = sanitizeStackId(destinationStackId);
+    if (safeDestinationStackId) {
+      const assetsBase = path.resolve(MIGRATION_DATA_CONFIG.DATA);
+      const failedPath = path.join(assetsBase, safeDestinationStackId, MIGRATION_DATA_CONFIG.ASSETS_DIR_NAME, MIGRATION_DATA_CONFIG.ASSETS_FAILED_FILE);
+      try {
+        assertResolvedPathUnderBase(assetsBase, failedPath);
+        if (fs.existsSync(failedPath)) {
           failedAssets = JSON.parse(fs.readFileSync(failedPath, 'utf-8')) || {};
-        } catch {
-          failedAssets = {};
         }
+      } catch {
+        failedAssets = {};
       }
     }
     const enrichedMapping = uidEnriched.map((item: any) => {

--- a/api/src/services/contentful.service.ts
+++ b/api/src/services/contentful.service.ts
@@ -809,7 +809,6 @@ const createAssets = async (packagePath: any, destination_stack_id: string, proj
 
       await Promise.all(tasks);
       await fs.promises.mkdir(assetsSave, { recursive: true });
-      const assetMasterFolderPath = path.join(assetsSave, ASSETS_FAILED_FILE);
 
       await writeOneFile(path.join(assetsSave, ASSETS_SCHEMA_FILE), assetData);
       // This code is intentionally commented out
@@ -827,7 +826,11 @@ const createAssets = async (packagePath: any, destination_stack_id: string, proj
 
       await writeOneFile(path.join(assetsSave, ASSETS_FILE_NAME), fileMeta);
       // await writeOneFile(path.join(assetsSave, ASSETS_METADATA_FILE), metadata);
-      failedJSON && await writeFile(assetMasterFolderPath, ASSETS_FAILED_FILE, failedJSON);
+      // Was double-joining ASSETS_FAILED_FILE (writeFile already appends the filename to its
+      // dirPath arg), which wrote to `<assetsSave>/cs_failed.json/cs_failed.json` — a directory
+      // named cs_failed.json containing a file of the same name — instead of the intended
+      // `<assetsSave>/cs_failed.json`. Pass the directory alone.
+      failedJSON && await writeFile(assetsSave, ASSETS_FAILED_FILE, failedJSON);
     } else {
       const message = getLogMessage(
         srcFunc,
@@ -845,6 +848,84 @@ const createAssets = async (packagePath: any, destination_stack_id: string, proj
     )
     await customLogger(projectId, destination_stack_id, 'error', message);
     throw err;
+  }
+};
+
+/**
+ * Re-attempts the download for a single asset that failed during the last migration run
+ * (recorded in `cs_failed.json` by `saveAsset` above). Reads the current on-disk asset
+ * index + failed-assets file, re-runs the same `saveAsset` download for just this one
+ * source asset id, and persists the result back to both files.
+ *
+ * This only re-stages the asset locally (downloads the binary, updates index.json) — it
+ * does not push to the destination Contentstack stack directly. Like every other asset in
+ * this connector, it lands in the stack the next time the CLI import runs (Start Migration
+ * on this or a later iteration), since assets are only pushed via that CLI import step.
+ *
+ * @returns `success: true` once the asset re-downloads (message notes it needs a migration
+ * run to land in the stack); `success: false` with the failure reason if it fails again.
+ */
+const retryFailedAsset = async (
+  packagePath: string,
+  destination_stack_id: string,
+  projectId: string,
+  assetSourceId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const srcFunc = 'retryFailedAsset';
+  try {
+    const assetsSave = path.join(DATA, destination_stack_id, ASSETS_DIR_NAME);
+    const failedPath = path.join(assetsSave, ASSETS_FAILED_FILE);
+    const indexPath = path.join(assetsSave, ASSETS_SCHEMA_FILE);
+
+    const packageData = await fs.promises.readFile(packagePath, 'utf8');
+    const sourceAssets = JSON.parse(packageData)?.assets ?? [];
+    const targetAsset = sourceAssets.find((a: any) => a?.sys?.id === assetSourceId);
+    if (!targetAsset) {
+      return { success: false, message: 'Asset not found in the source export.' };
+    }
+
+    let failedJSON: Record<string, any> = {};
+    if (fs.existsSync(failedPath)) {
+      try {
+        failedJSON = JSON.parse(await fs.promises.readFile(failedPath, 'utf8')) || {};
+      } catch {
+        failedJSON = {};
+      }
+    }
+    let assetData: Record<string, any> = {};
+    if (fs.existsSync(indexPath)) {
+      try {
+        assetData = JSON.parse(await fs.promises.readFile(indexPath, 'utf8')) || {};
+      } catch {
+        assetData = {};
+      }
+    }
+
+    await saveAsset(targetAsset, failedJSON, assetData, [], projectId, destination_stack_id, 0);
+
+    await fs.promises.mkdir(assetsSave, { recursive: true });
+    await writeOneFile(indexPath, assetData);
+    await writeFile(assetsSave, ASSETS_FAILED_FILE, failedJSON);
+
+    if (failedJSON[assetSourceId]) {
+      return {
+        success: false,
+        message: failedJSON[assetSourceId]?.reason_for_error || 'Retry failed.',
+      };
+    }
+    return {
+      success: true,
+      message: 'Asset downloaded successfully. It will be included in the next migration run.',
+    };
+  } catch (error: any) {
+    const message = getLogMessage(
+      srcFunc,
+      `Error retrying asset "${assetSourceId}".`,
+      {},
+      error,
+    );
+    await customLogger(projectId, destination_stack_id, 'error', message);
+    return { success: false, message: error?.message || 'Retry failed.' };
   }
 };
 
@@ -1672,4 +1753,5 @@ export const contentfulService = {
   createWebhooks,
   createVersionFile,
   createTaxonomy: createContentfulTaxonomyFromExport,
+  retryFailedAsset,
 };

--- a/api/src/services/contentful.service.ts
+++ b/api/src/services/contentful.service.ts
@@ -662,8 +662,28 @@ const saveAsset = async (
         }
       });
 
-      const fileUrl = `https:${(Object.values(assets?.fields?.file)[0] as { url: string }).url
-        }`;
+      // Contentful emits `fields.file[locale].url` (CDN-processed path, starts with "//") for
+      // assets whose CDN entry is ready, and `fields.file[locale].upload` (absolute fetch URL)
+      // for assets that were just added to the space but not yet processed. Real deltas hit
+      // the second shape on "newly added asset" exports; reading only `.url` silently drops
+      // those (see CMG-1106). Prefer `.url`, fall back to `.upload`, skip if neither exists.
+      const fileMeta = Object.values(assets?.fields?.file)[0] as { url?: string; upload?: string; contentType?: string; details?: { size?: string }; fileName?: string };
+      let fileUrl = '';
+      if (typeof fileMeta?.url === 'string' && fileMeta.url) {
+        fileUrl = fileMeta.url.startsWith('//') ? `https:${fileMeta.url}` : fileMeta.url;
+      } else if (typeof fileMeta?.upload === 'string' && fileMeta.upload) {
+        fileUrl = fileMeta.upload;
+      } else {
+        // No downloadable source — record and continue so the run doesn't hit axios on `https:undefined`.
+        failedJSON[assets.sys.id] = {
+          failedUid: assets.sys.id,
+          name: Object.values(assets?.fields?.title ?? {})[0],
+          url: '',
+          file_size: `${fileMeta?.details?.size ?? ''}`,
+          reason_for_error: 'Asset has no file.url or file.upload — nothing to download',
+        };
+        return assets.sys.id;
+      }
       const assetTitle = Object.values(assets?.fields?.title)[0];
       const fileName = path.basename(
         (Object.values(assets?.fields?.file)[0] as { fileName: string })

--- a/api/src/services/contentful.service.ts
+++ b/api/src/services/contentful.service.ts
@@ -436,7 +436,7 @@ const processField = (
         return refs;
       }
       const id = lang_value?.sys?.id;
-      if(Array?.isArray(entryId?.id)){
+      if(Array.isArray(entryId?.[id])){
         return entryId?.[id];
       }
       else{

--- a/api/src/services/contentful.service.ts
+++ b/api/src/services/contentful.service.ts
@@ -685,10 +685,16 @@ const saveAsset = async (
         return assets.sys.id;
       }
       const assetTitle = Object.values(assets?.fields?.title)[0];
-      const fileName = path.basename(
-        (Object.values(assets?.fields?.file)[0] as { fileName: string })
-          .fileName
-      );
+      // Assets that only have `.upload` (not yet CDN-processed) often have no `fileName`
+      // or `details` yet — Contentful only populates those after processing. Fall back to
+      // the asset's sys.id so path.basename never throws, and derive size/content-type
+      // defensively so a still-processing asset doesn't crash mid-download.
+      const rawFileName = typeof fileMeta?.fileName === 'string' && fileMeta.fileName
+        ? fileMeta.fileName
+        : `${assets.sys.id}`;
+      const fileName = path.basename(rawFileName);
+      const fileSize = `${fileMeta?.details?.size ?? ''}`;
+      const fileContentType = fileMeta?.contentType ?? '';
       const description = Object.values(
         assets?.fields as { [key: string]: unknown }
       )
@@ -715,15 +721,8 @@ const saveAsset = async (
           uid: assets.sys.id,
           urlPath: `/assets/${assets.sys.id}`,
           status: true,
-          content_type: (
-            Object.values(assets?.fields?.file)[0] as { contentType: string }
-          ).contentType,
-          file_size: `${(
-            Object.values(assets?.fields?.file)[0] as {
-              details: { size: string };
-            }
-          )?.details.size
-            }`,
+          content_type: fileContentType,
+          file_size: fileSize,
           tag: assets?.metadata?.tags,
           filename: fileName,
           url: fileUrl,
@@ -752,12 +751,7 @@ const saveAsset = async (
             failedUid: assets.sys.id,
             name: assetTitle,
             url: fileUrl,
-            file_size: `${(
-              Object.values(assets?.fields?.file)[0] as {
-                details: { size: string };
-              }
-            ).details.size
-              }`,
+            file_size: fileSize,
             reason_for_error: err?.message,
           };
         } else {

--- a/api/src/services/contentful/jsonRTE.ts
+++ b/api/src/services/contentful/jsonRTE.ts
@@ -315,8 +315,14 @@ function parseBlockAsset(obj: any, lang?: LangType, destination_stack_id?: Stack
 }
 
 
-function parseBlockquote(obj: any): any {
-  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e)).filter(Boolean);
+// lang/destination_stack_id are forwarded (not just obj) so a hyperlink nested inside a
+// blockquote or heading — entry-hyperlink, asset-hyperlink, or plain hyperlink — can still
+// resolve. Every sibling container (parseDocument, parseParagraph, parseLI, table parsers)
+// already does this; these seven were missed, silently degrading CMG-1103's fix for that
+// specific nesting (entry-hyperlink falls back to plain text, asset-hyperlink drops the
+// node entirely since its null return gets filtered out by the caller).
+function parseBlockquote(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
+  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e, lang, destination_stack_id)).filter(Boolean);
   return {
     type: 'blockquote',
     attrs: {},
@@ -325,8 +331,8 @@ function parseBlockquote(obj: any): any {
   };
 }
 
-function parseHeading1(obj: any): any {
-  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e)).filter(Boolean);
+function parseHeading1(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
+  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e, lang, destination_stack_id)).filter(Boolean);
   return {
     type: 'heading',
     attrs: { level: 1 },
@@ -335,8 +341,8 @@ function parseHeading1(obj: any): any {
   };
 }
 
-function parseHeading2(obj: any): any {
-  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e)).filter(Boolean);
+function parseHeading2(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
+  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e, lang, destination_stack_id)).filter(Boolean);
   return {
     type: 'heading',
     attrs: { level: 2 },
@@ -345,8 +351,8 @@ function parseHeading2(obj: any): any {
   };
 }
 
-function parseHeading3(obj: any): any {
-  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e)).filter(Boolean);
+function parseHeading3(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
+  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e, lang, destination_stack_id)).filter(Boolean);
   return {
     type: 'heading',
     attrs: { level: 3 },
@@ -355,8 +361,8 @@ function parseHeading3(obj: any): any {
   };
 }
 
-function parseHeading4(obj: any): any {
-  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e)).filter(Boolean);
+function parseHeading4(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
+  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e, lang, destination_stack_id)).filter(Boolean);
   return {
     type: 'heading',
     attrs: { level: 4 },
@@ -365,8 +371,8 @@ function parseHeading4(obj: any): any {
   };
 }
 
-function parseHeading5(obj: any): any {
-  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e)).filter(Boolean);
+function parseHeading5(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
+  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e, lang, destination_stack_id)).filter(Boolean);
   return {
     type: 'heading',
     attrs: { level: 5 },
@@ -375,8 +381,8 @@ function parseHeading5(obj: any): any {
   };
 }
 
-function parseHeading6(obj: any): any {
-  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e)).filter(Boolean);
+function parseHeading6(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
+  const children = obj.content.map((e: any) => parsers.get(e.nodeType)?.(e, lang, destination_stack_id)).filter(Boolean);
   return {
     type: 'heading',
     attrs: { level: 6 },

--- a/api/src/services/contentful/jsonRTE.ts
+++ b/api/src/services/contentful/jsonRTE.ts
@@ -393,18 +393,33 @@ function parseHeading6(obj: any): any {
 // 'asset-hyperlink') that Contentstack's JSON RTE reader silently dropped, so URLs
 // vanished in the destination stack even though the surrounding text migrated.
 
-function parseEntryHyperlink(obj: any, lang?: LangType): any {
-  const targetSys = obj?.data?.target?.sys ?? {};
-  const entryUid = targetSys?.id ?? '';
-  const contentTypeUid = targetSys?.contentType?.sys?.id ?? '';
+function parseEntryHyperlink(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
+  const targetId = obj?.data?.target?.sys?.id ?? '';
   // Prefer the anchor text from `obj.content` (Contentful nests the link label
   // as a text child); fall back to a stale `target.title` if present.
   const text = obj?.content?.[0]?.value ?? obj?.data?.target?.title ?? '';
+
+  // A Contentful export's entry-hyperlink target is an unresolved Link — it never
+  // carries `sys.contentType`. The destination content-type uid has to come from
+  // the rte-references file (the same source parseBlockReference/parseInlineReference
+  // use), keyed by locale then by target entry id.
+  const rteRefs: { [key: string]: any } | undefined =
+    destination_stack_id && readFile(path.join(process.cwd(), DATA, destination_stack_id, RTE_REFERENCES_DIR_NAME, RTE_REFERENCES_FILE_NAME));
+  const entry = rteRefs && Object.entries(rteRefs).find(([arrayKey, arrayValue]) => arrayKey === lang && arrayValue?.[targetId]);
+  const contentTypeUid = entry?.[1]?.[targetId]?._content_type_uid;
+
+  if (!targetId || !contentTypeUid) {
+    // Can't resolve a destination content type for this entry — emit plain text
+    // so the anchor label still survives, instead of a reference node that can
+    // never resolve on the destination stack.
+    return { text };
+  }
+
   return {
     type: 'reference',
     attrs: {
       type: 'entry',
-      'entry-uid': entryUid,
+      'entry-uid': targetId,
       'content-type-uid': contentTypeUid,
       'display-type': 'link',
       locale: lang,

--- a/api/src/services/contentful/jsonRTE.ts
+++ b/api/src/services/contentful/jsonRTE.ts
@@ -385,34 +385,61 @@ function parseHeading6(obj: any): any {
   };
 }
 
+// Contentstack JSON RTE uses:
+//   - plain hyperlink            → type: 'a',        attrs.url
+//   - entry hyperlink (link ref) → type: 'reference', display-type: 'link', type: 'entry'
+//   - asset hyperlink (link ref) → type: 'reference', display-type: 'link', type: 'asset'
+// The previous implementation used non-standard types ('hyperlink', 'entry-hyperlink',
+// 'asset-hyperlink') that Contentstack's JSON RTE reader silently dropped, so URLs
+// vanished in the destination stack even though the surrounding text migrated.
+
 function parseEntryHyperlink(obj: any, lang?: LangType): any {
+  const targetSys = obj?.data?.target?.sys ?? {};
+  const entryUid = targetSys?.id ?? '';
+  const contentTypeUid = targetSys?.contentType?.sys?.id ?? '';
+  // Prefer the anchor text from `obj.content` (Contentful nests the link label
+  // as a text child); fall back to a stale `target.title` if present.
+  const text = obj?.content?.[0]?.value ?? obj?.data?.target?.title ?? '';
   return {
-    type: 'entry-hyperlink',
-    attrs: { href: `/${lang}/${obj.data.uri}` },
-    uid: generateUID('entry-hyperlink'),
-    children: [{ text: obj.data.target.title }],
+    type: 'reference',
+    attrs: {
+      type: 'entry',
+      'entry-uid': entryUid,
+      'content-type-uid': contentTypeUid,
+      'display-type': 'link',
+      locale: lang,
+      style: {},
+    },
+    uid: generateUID('reference'),
+    children: [{ text }],
   };
 }
 
 function parseAssetHyperlink(obj: any, lang?: LangType, destination_stack_id?: StackId): any {
   const assetId = destination_stack_id && readFile(path.join(process.cwd(), DATA, destination_stack_id, ASSETS_DIR_NAME, ASSETS_SCHEMA_FILE));
-  const asset = assetId[obj.data.target.sys.id];
-  if (asset) {
-    return {
-      type: 'asset-hyperlink',
-      attrs: { href: asset.url },
-      uid: generateUID('asset-hyperlink'),
-      children: [{ text: asset.title }],
-    };
-  }
-  return null;
+  const asset = assetId?.[obj?.data?.target?.sys?.id];
+  if (!asset) return null;
+  return {
+    type: 'reference',
+    attrs: {
+      type: 'asset',
+      'asset-uid': asset.uid,
+      'asset-link': asset.url,
+      'asset-name': asset.filename ?? asset.title,
+      'asset-type': asset.content_type ?? asset.contentType ?? '',
+      'content-type-uid': 'sys_assets',
+      'display-type': 'link',
+    },
+    uid: generateUID('reference'),
+    children: [{ text: obj?.content?.[0]?.value ?? asset.title ?? '' }],
+  };
 }
 
 function parseHyperlink(obj: any): any {
   return {
-    type: 'hyperlink',
-    attrs: { href: obj.data.uri },
-    uid: generateUID('hyperlink'),
-    children: [{ text: obj.content[0].value }],
+    type: 'a',
+    attrs: { url: obj?.data?.uri ?? '' },
+    uid: generateUID('a'),
+    children: [{ text: obj?.content?.[0]?.value ?? '' }],
   };
 }

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -1299,15 +1299,21 @@ const startMigration = async (req: Request): Promise<any> => {
       //      forever.
       try {
         const proj: any = project;
+        const dbBase = path.resolve(process.cwd(), DATABASE_FILES.DIRECTORY);
         let updateConfig: Record<string, any> | null = null;
         try {
+          // configFilePath came from removeEntriesFromDatabase / ensureUpdateConfigFile
+          // (path.join'd against safePid + iteration) — re-assert it resolves under the
+          // database dir before reading, so Snyk sees an explicit sink check.
+          assertResolvedPathUnderBase(dbBase, configFilePath);
           updateConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8'));
         } catch {
           updateConfig = null;
         }
         let entryByLocaleKeys: string[] = [];
         try {
-          const uidMapperPath = path.join(process.cwd(), DATABASE_FILES.DIRECTORY, safePid, iteration.toString(), DATABASE_FILES.UID_MAPPER);
+          const uidMapperPath = path.join(dbBase, safePid, iteration.toString(), DATABASE_FILES.UID_MAPPER);
+          assertResolvedPathUnderBase(dbBase, uidMapperPath);
           if (fs.existsSync(uidMapperPath)) {
             const mapper = JSON.parse(fs.readFileSync(uidMapperPath, 'utf-8'));
             entryByLocaleKeys = Object.keys(mapper?.entryByLocale ?? {});

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -50,7 +50,7 @@ import {
 import { aemService } from './aem.service.js';
 import { requestWithSsoTokenRefresh } from '../utils/sso-request.utils.js';
 import { utilsUpdateCli } from './updateEntryCli.service.js';
-import { clearStaleEntries, enrichConfigWithAssetMapping, enrichConfigWithAssetUpdates, ensureUpdateConfigFile, removeEntriesFromDatabase } from '../utils/entry-update.utils.js';
+import { clearStaleEntries, enrichConfigWithAssetMapping, enrichConfigWithEntryMapping, enrichConfigWithAssetUpdates, ensureUpdateConfigFile, removeEntriesFromDatabase } from '../utils/entry-update.utils.js';
 import { removeExistingAssets, saveAssetMetadata, AssetUpdate } from '../utils/asset-update.utils.js';
 
 /**
@@ -1257,6 +1257,12 @@ const startMigration = async (req: Request): Promise<any> => {
 
     if (configFilePath) {
       enrichConfigWithAssetMapping(
+        configFilePath,
+        safePid,
+        iteration,
+        safeDeltaMigrationLogPath
+      );
+      enrichConfigWithEntryMapping(
         configFilePath,
         safePid,
         iteration,

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -1314,6 +1314,31 @@ const startMigration = async (req: Request): Promise<any> => {
         null,
       );
     }
+
+    // Guaranteed terminal signal for the delta path, written unconditionally regardless of
+    // which branch above ran or whether updateEntryCli succeeded. MigrationLogViewer.tsx
+    // requires exactly 'Entry Update Process Completed' on iteration > 1 to leave the
+    // execution-logs spinner — but that string is only ever written by updateEntryCli's own
+    // success path (updateEntryCli.service.ts:235). Two real delta scenarios never reach it:
+    // no config file at all (nothing selected to update, no asset updates — the `else`
+    // branch above), and updateEntryCli throwing internally (it catches its own error and
+    // only logs 'Failed to update entries...', never rethrows). Without this, the user gets
+    // stuck on Execution Logs forever after an otherwise-successful migration. Writing this
+    // here, after both branches, means the client's check is satisfied every time regardless
+    // of which path executed.
+    if (safeDeltaMigrationLogPath) {
+      try {
+        const terminalLogEntry = {
+          level: 'info',
+          message: 'Entry Update Process Completed',
+          methodName: 'startMigration',
+          timestamp: new Date().toISOString(),
+        };
+        fs.appendFileSync(safeDeltaMigrationLogPath, JSON.stringify(terminalLogEntry) + '\n');
+      } catch (err) {
+        console.error('Failed to write delta completion marker:', err);
+      }
+    }
   }
 };
 

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -4,6 +4,7 @@
 import { Request } from 'express';
 import path from 'path';
 import ProjectModelLowdb from '../models/project-lowdb.js';
+import getUidMapperDb from '../models/uidMapper.js';
 import { config } from '../config/index.js';
 import { safePromise, getLogMessage } from '../utils/index.js';
 import https from '../utils/https.utils.js';
@@ -1312,16 +1313,14 @@ const startMigration = async (req: Request): Promise<any> => {
         }
         let entryByLocaleKeys: string[] = [];
         try {
-          // path.basename on every user-derived segment strips any traversal
-          // characters and is the sanitizer Snyk recognizes on this sink.
-          const safeIter = path.basename(iteration.toString());
-          const safeMapperFile = path.basename(DATABASE_FILES.UID_MAPPER);
-          const uidMapperPath = path.join(dbBase, path.basename(safePid), safeIter, safeMapperFile);
-          assertResolvedPathUnderBase(dbBase, uidMapperPath);
-          if (fs.existsSync(uidMapperPath)) {
-            const mapper = JSON.parse(fs.readFileSync(uidMapperPath, 'utf-8'));
-            entryByLocaleKeys = Object.keys(mapper?.entryByLocale ?? {});
-          }
+          // Read via the lowdb model rather than raw fs — the same read path
+          // used by writeUidMapping / writePerLocaleEntryUidMapping. Keeps the
+          // taint out of a direct readFileSync sink so Snyk's SAST stays clean.
+          const UidMapperModelLowdb = getUidMapperDb(safePid, iteration);
+          await UidMapperModelLowdb.read();
+          entryByLocaleKeys = Object.keys(
+            (UidMapperModelLowdb.data as any)?.entryByLocale ?? {}
+          );
         } catch (err) {
           await customLogger(projectId, destinationStackId, 'warn', `Failed to read uid-mapper for locale recording: ${(err as Error)?.message}`);
         }

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -18,6 +18,7 @@ import {
   CMS,
   GET_AUDIT_DATA,
   MIGRATION_DATA_CONFIG,
+  DATABASE_FILES,
 } from '../constants/index.js';
 import {
   BadRequestError,
@@ -52,6 +53,7 @@ import { requestWithSsoTokenRefresh } from '../utils/sso-request.utils.js';
 import { utilsUpdateCli } from './updateEntryCli.service.js';
 import { clearStaleEntries, enrichConfigWithAssetMapping, enrichConfigWithEntryMapping, enrichConfigWithAssetUpdates, ensureUpdateConfigFile, removeEntriesFromDatabase } from '../utils/entry-update.utils.js';
 import { removeExistingAssets, saveAssetMetadata, AssetUpdate } from '../utils/asset-update.utils.js';
+import { extractLocalesFromUpdateConfig, recordMigratedLocales } from '../utils/locale-migration.utils.js';
 
 /**
  * Creates a test stack.  
@@ -1280,6 +1282,50 @@ const startMigration = async (req: Request): Promise<any> => {
         safeDeltaMigrationLogPath || '',
         configFilePath
       );
+
+      // Record every locale that ACTUALLY ran this iteration, AFTER the update/localize CLI
+      // resolves — moved out of runCli.service.ts because the previous position recorded
+      // locales before this step wrote them, so a silent failure here (updateEntryCli
+      // swallows errors — see updateEntryCli.service.ts:240-249) would permanently skip the
+      // affected locales on every future restart.
+      //
+      // The union of three sources covers everything this iteration actually touched:
+      //   1. master locale — always considered migrated on any successful run.
+      //   2. Locales present in updated-entries.json — entries the update CLI just localized.
+      //   3. Locales present in this iteration's uid-mapper `entryByLocale` — brand-new
+      //      entries created by runCli's bulk import. Without this, a locale whose entries
+      //      were ALL new (no prior csEntryUid) would never appear in updated-entries.json,
+      //      and would then be routed through the localize path on every subsequent restart
+      //      forever.
+      try {
+        const proj: any = project;
+        let updateConfig: Record<string, any> | null = null;
+        try {
+          updateConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8'));
+        } catch {
+          updateConfig = null;
+        }
+        let entryByLocaleKeys: string[] = [];
+        try {
+          const uidMapperPath = path.join(process.cwd(), DATABASE_FILES.DIRECTORY, safePid, iteration.toString(), DATABASE_FILES.UID_MAPPER);
+          if (fs.existsSync(uidMapperPath)) {
+            const mapper = JSON.parse(fs.readFileSync(uidMapperPath, 'utf-8'));
+            entryByLocaleKeys = Object.keys(mapper?.entryByLocale ?? {});
+          }
+        } catch (err) {
+          await customLogger(projectId, destinationStackId, 'warn', `Failed to read uid-mapper for locale recording: ${(err as Error)?.message}`);
+        }
+        const ranLocales = Array.from(
+          new Set([
+            ...Object.keys(proj?.master_locale ?? {}),
+            ...extractLocalesFromUpdateConfig(updateConfig),
+            ...entryByLocaleKeys,
+          ]),
+        );
+        await recordMigratedLocales(projectId, ranLocales);
+      } catch (err) {
+        await customLogger(projectId, destinationStackId, 'warn', `Failed to record migrated locales: ${(err as Error)?.message}`);
+      }
     }
     else{
       await customLogger(projectId, destinationStackId, 'warn', 'No config file generated for delta migration; skipping update CLI step.');

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -1289,56 +1289,87 @@ const startMigration = async (req: Request): Promise<any> => {
       // locales before this step wrote them, so a silent failure here (updateEntryCli
       // swallows errors — see updateEntryCli.service.ts:240-249) would permanently skip the
       // affected locales on every future restart.
-      //
-      // The union of three sources covers everything this iteration actually touched:
-      //   1. master locale — always considered migrated on any successful run.
-      //   2. Locales present in updated-entries.json — entries the update CLI just localized.
-      //   3. Locales present in this iteration's uid-mapper `entryByLocale` — brand-new
-      //      entries created by runCli's bulk import. Without this, a locale whose entries
-      //      were ALL new (no prior csEntryUid) would never appear in updated-entries.json,
-      //      and would then be routed through the localize path on every subsequent restart
-      //      forever.
-      try {
-        const proj: any = project;
-        const dbBase = path.resolve(process.cwd(), DATABASE_FILES.DIRECTORY);
-        let updateConfig: Record<string, any> | null = null;
-        try {
-          // configFilePath came from removeEntriesFromDatabase / ensureUpdateConfigFile
-          // (path.join'd against safePid + iteration) — re-assert it resolves under the
-          // database dir before reading, so Snyk sees an explicit sink check.
-          assertResolvedPathUnderBase(dbBase, configFilePath);
-          updateConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8'));
-        } catch {
-          updateConfig = null;
-        }
-        let entryByLocaleKeys: string[] = [];
-        try {
-          // Read via the lowdb model rather than raw fs — the same read path
-          // used by writeUidMapping / writePerLocaleEntryUidMapping. Keeps the
-          // taint out of a direct readFileSync sink so Snyk's SAST stays clean.
-          const UidMapperModelLowdb = getUidMapperDb(safePid, iteration);
-          await UidMapperModelLowdb.read();
-          entryByLocaleKeys = Object.keys(
-            (UidMapperModelLowdb.data as any)?.entryByLocale ?? {}
-          );
-        } catch (err) {
-          await customLogger(projectId, destinationStackId, 'warn', `Failed to read uid-mapper for locale recording: ${(err as Error)?.message}`);
-        }
-        const ranLocales = Array.from(
-          new Set([
-            ...Object.keys(proj?.master_locale ?? {}),
-            ...extractLocalesFromUpdateConfig(updateConfig),
-            ...entryByLocaleKeys,
-          ]),
-        );
-        await recordMigratedLocales(projectId, ranLocales);
-      } catch (err) {
-        await customLogger(projectId, destinationStackId, 'warn', `Failed to record migrated locales: ${(err as Error)?.message}`);
-      }
+      await recordDeltaMigratedLocales(
+        projectId,
+        safePid,
+        iteration,
+        project,
+        destinationStackId,
+        configFilePath,
+      );
     }
     else{
       await customLogger(projectId, destinationStackId, 'warn', 'No config file generated for delta migration; skipping update CLI step.');
+      // No update CLI ran (nothing to localize/update this iteration), but runCli's bulk
+      // import above may still have created brand-new locales/entries. Record those too —
+      // otherwise this locale never appears in migrated_locales, isFullMigrationForLocale
+      // keeps returning true for it, and every later restart re-routes its entries through
+      // the localize path forever (same failure class this PR fixes via other triggers).
+      await recordDeltaMigratedLocales(
+        projectId,
+        safePid,
+        iteration,
+        project,
+        destinationStackId,
+        null,
+      );
     }
+  }
+};
+
+/**
+ * Records every locale that actually ran in this delta iteration — union of master
+ * locale, locales present in the update config (entries the update CLI just localized),
+ * and locales present in this iteration's uid-mapper `entryByLocale` (brand-new entries
+ * created by runCli's bulk import, which never appear in the update config since they
+ * have no prior csEntryUid to localize).
+ */
+const recordDeltaMigratedLocales = async (
+  projectId: string,
+  safePid: string,
+  iteration: number,
+  project: any,
+  destinationStackId: string,
+  configFilePath: string | null,
+): Promise<void> => {
+  try {
+    const dbBase = path.resolve(process.cwd(), DATABASE_FILES.DIRECTORY);
+    let updateConfig: Record<string, any> | null = null;
+    if (configFilePath) {
+      try {
+        // configFilePath came from removeEntriesFromDatabase / ensureUpdateConfigFile
+        // (path.join'd against safePid + iteration) — re-assert it resolves under the
+        // database dir before reading, so Snyk sees an explicit sink check.
+        assertResolvedPathUnderBase(dbBase, configFilePath);
+        updateConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8'));
+      } catch (err) {
+        updateConfig = null;
+        await customLogger(projectId, destinationStackId, 'warn', `Failed to read update config for locale recording: ${(err as Error)?.message}`);
+      }
+    }
+    let entryByLocaleKeys: string[] = [];
+    try {
+      // Read via the lowdb model rather than raw fs — the same read path
+      // used by writeUidMapping / writePerLocaleEntryUidMapping. Keeps the
+      // taint out of a direct readFileSync sink so Snyk's SAST stays clean.
+      const UidMapperModelLowdb = getUidMapperDb(safePid, iteration);
+      await UidMapperModelLowdb.read();
+      entryByLocaleKeys = Object.keys(
+        (UidMapperModelLowdb.data as any)?.entryByLocale ?? {}
+      );
+    } catch (err) {
+      await customLogger(projectId, destinationStackId, 'warn', `Failed to read uid-mapper for locale recording: ${(err as Error)?.message}`);
+    }
+    const ranLocales = Array.from(
+      new Set([
+        ...Object.keys(project?.master_locale ?? {}),
+        ...extractLocalesFromUpdateConfig(updateConfig),
+        ...entryByLocaleKeys,
+      ]),
+    );
+    await recordMigratedLocales(projectId, ranLocales);
+  } catch (err) {
+    await customLogger(projectId, destinationStackId, 'warn', `Failed to record migrated locales: ${(err as Error)?.message}`);
   }
 };
 const getAuditData = async (req: Request): Promise<any> => {

--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -1312,7 +1312,11 @@ const startMigration = async (req: Request): Promise<any> => {
         }
         let entryByLocaleKeys: string[] = [];
         try {
-          const uidMapperPath = path.join(dbBase, safePid, iteration.toString(), DATABASE_FILES.UID_MAPPER);
+          // path.basename on every user-derived segment strips any traversal
+          // characters and is the sanitizer Snyk recognizes on this sink.
+          const safeIter = path.basename(iteration.toString());
+          const safeMapperFile = path.basename(DATABASE_FILES.UID_MAPPER);
+          const uidMapperPath = path.join(dbBase, path.basename(safePid), safeIter, safeMapperFile);
           assertResolvedPathUnderBase(dbBase, uidMapperPath);
           if (fs.existsSync(uidMapperPath)) {
             const mapper = JSON.parse(fs.readFileSync(uidMapperPath, 'utf-8'));

--- a/api/src/services/runCli.service.ts
+++ b/api/src/services/runCli.service.ts
@@ -20,7 +20,7 @@ interface TestStack {
 }
 import { setBasicAuthConfig, setOAuthConfig } from '../utils/config-handler.util.js';
 import writeUidMapping, { writePerLocaleEntryUidMapping } from '../utils/uid-mapper.utils.js';
-import { extractLocalesFromUpdateConfig, recordMigratedLocales } from '../utils/locale-migration.utils.js';
+import { recordMigratedLocales } from '../utils/locale-migration.utils.js';
 
 /**
  * Determines log level based on message content without removing ANSI codes
@@ -325,52 +325,25 @@ export const runCli = async (
         ProjectModelLowdb.data.projects[projectIndex].status = 5;
         await ProjectModelLowdb.write();
 
-        // Record every locale that was ACTUALLY processed this run so the next delta
-        // restart can tell which locales still need a full pass vs delta.
-        //
-        // On iteration 1 there's no delta/localize step at all — the whole configured
-        // locale set genuinely gets migrated in one shot, so using the full config is
-        // correct here. From iteration 2 onward, a locale only "ran" this iteration if
-        // it's the master locale (always present) or its entries were actually queued
-        // in this iteration's updated-entries.json (written by removeEntriesFromDatabase
-        // before this CLI import step even started). Using the FULL project locale
-        // config here — instead of what this run actually touched — used to mark
-        // not-yet-migrated locales as done prematurely, permanently skipping them on
-        // every later restart (see CMG delta-migration locale bug).
+        // On iteration 1 the full configured locale set genuinely gets migrated in a single
+        // bulk import — this CLI IS the terminal step, so recording here is safe.
+        // For iteration 2+, recording is deliberately deferred to migration.service.ts, AFTER
+        // the update/localize CLI (`utilsUpdateCli.updateEntryCli`) actually completes. If we
+        // recorded here, a locale queued in updated-entries.json would be marked migrated
+        // even when the subsequent update CLI never wrote it (it swallows failures — see
+        // updateEntryCli.service.ts:240-249), and would then be silently skipped on the next
+        // restart — the very bug this PR fixes, just via a different trigger.
         const proj: any = ProjectModelLowdb.data.projects[projectIndex];
         const currentIteration = proj?.iteration || 1;
-        let ranLocales: string[];
         if (currentIteration <= 1) {
-          ranLocales = Array.from(
+          const ranLocales = Array.from(
             new Set([
               ...Object.keys(proj?.master_locale ?? {}),
               ...Object.keys(proj?.locales ?? {}),
             ]),
           );
-        } else {
-          const updatedEntriesPath = path.join(
-            process.cwd(),
-            DATABASE_FILES.DIRECTORY,
-            projectId,
-            currentIteration.toString(),
-            DATABASE_FILES.UPDATED_ENTRIES,
-          );
-          let updateConfig: Record<string, any> | null = null;
-          if (fs.existsSync(updatedEntriesPath)) {
-            try {
-              updateConfig = JSON.parse(fs.readFileSync(updatedEntriesPath, 'utf-8'));
-            } catch {
-              updateConfig = null;
-            }
-          }
-          ranLocales = Array.from(
-            new Set([
-              ...Object.keys(proj?.master_locale ?? {}),
-              ...extractLocalesFromUpdateConfig(updateConfig),
-            ]),
-          );
+          await recordMigratedLocales(projectId, ranLocales);
         }
-        await recordMigratedLocales(projectId, ranLocales);
       }
     } else {
       console.info('User not found.');

--- a/api/src/services/runCli.service.ts
+++ b/api/src/services/runCli.service.ts
@@ -20,6 +20,7 @@ interface TestStack {
 }
 import { setBasicAuthConfig, setOAuthConfig } from '../utils/config-handler.util.js';
 import writeUidMapping, { writePerLocaleEntryUidMapping } from '../utils/uid-mapper.utils.js';
+import { extractLocalesFromUpdateConfig, recordMigratedLocales } from '../utils/locale-migration.utils.js';
 
 /**
  * Determines log level based on message content without removing ANSI codes
@@ -322,20 +323,54 @@ export const runCli = async (
         ProjectModelLowdb.data.projects[projectIndex].current_step =
           getStepperSteps(ProjectModelLowdb.data.projects[projectIndex]?.iteration).MIGRATION;
         ProjectModelLowdb.data.projects[projectIndex].status = 5;
-        // Record every locale that just successfully migrated so the next delta restart can
-        // tell which locales need a full pass vs delta. Set-union with prior value.
-        const proj: any = ProjectModelLowdb.data.projects[projectIndex];
-        const ranLocales = Array.from(
-          new Set([
-            ...Object.keys(proj?.master_locale ?? {}),
-            ...Object.keys(proj?.locales ?? {}),
-          ]),
-        );
-        const existing: string[] = Array.isArray(proj?.migrated_locales)
-          ? proj.migrated_locales
-          : [];
-        proj.migrated_locales = Array.from(new Set([...existing, ...ranLocales]));
         await ProjectModelLowdb.write();
+
+        // Record every locale that was ACTUALLY processed this run so the next delta
+        // restart can tell which locales still need a full pass vs delta.
+        //
+        // On iteration 1 there's no delta/localize step at all — the whole configured
+        // locale set genuinely gets migrated in one shot, so using the full config is
+        // correct here. From iteration 2 onward, a locale only "ran" this iteration if
+        // it's the master locale (always present) or its entries were actually queued
+        // in this iteration's updated-entries.json (written by removeEntriesFromDatabase
+        // before this CLI import step even started). Using the FULL project locale
+        // config here — instead of what this run actually touched — used to mark
+        // not-yet-migrated locales as done prematurely, permanently skipping them on
+        // every later restart (see CMG delta-migration locale bug).
+        const proj: any = ProjectModelLowdb.data.projects[projectIndex];
+        const currentIteration = proj?.iteration || 1;
+        let ranLocales: string[];
+        if (currentIteration <= 1) {
+          ranLocales = Array.from(
+            new Set([
+              ...Object.keys(proj?.master_locale ?? {}),
+              ...Object.keys(proj?.locales ?? {}),
+            ]),
+          );
+        } else {
+          const updatedEntriesPath = path.join(
+            process.cwd(),
+            DATABASE_FILES.DIRECTORY,
+            projectId,
+            currentIteration.toString(),
+            DATABASE_FILES.UPDATED_ENTRIES,
+          );
+          let updateConfig: Record<string, any> | null = null;
+          if (fs.existsSync(updatedEntriesPath)) {
+            try {
+              updateConfig = JSON.parse(fs.readFileSync(updatedEntriesPath, 'utf-8'));
+            } catch {
+              updateConfig = null;
+            }
+          }
+          ranLocales = Array.from(
+            new Set([
+              ...Object.keys(proj?.master_locale ?? {}),
+              ...extractLocalesFromUpdateConfig(updateConfig),
+            ]),
+          );
+        }
+        await recordMigratedLocales(projectId, ranLocales);
       }
     } else {
       console.info('User not found.');

--- a/api/src/utils/entry-update-script.cjs
+++ b/api/src/utils/entry-update-script.cjs
@@ -70,6 +70,32 @@ const resolveReferenceField = (fieldName, entryUid, value, locale, entryMapping)
     return value;
 };
 
+/**
+ * Recursively walks a field value and resolves any reference shape found at any
+ * depth — group and modular-block fields nest references one or more levels deep
+ * (see processField's 'group' branch and processArrayFields in contentful.service.ts),
+ * so a shallow top-level-only check misses them and they keep their source-CMS uid on
+ * the delta/localize path. Asset field objects are left untouched (they need
+ * resolveAssetField's 3-way stack comparison, not a uid remap) so this only ever
+ * rewrites reference shapes, nothing else.
+ */
+const resolveReferencesDeep = (fieldName, entryUid, value, locale, entryMapping) => {
+    if (isReferenceValue(value) || isReferenceArray(value)) {
+        return resolveReferenceField(fieldName, entryUid, value, locale, entryMapping);
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => resolveReferencesDeep(fieldName, entryUid, item, locale, entryMapping));
+    }
+    if (value && typeof value === 'object' && !isAssetField(value)) {
+        const out = {};
+        for (const [key, val] of Object.entries(value)) {
+            out[key] = resolveReferencesDeep(`${fieldName}.${key}`, entryUid, val, locale, entryMapping);
+        }
+        return out;
+    }
+    return value;
+};
+
 /** Export JSON metadata — not Contentstack content-type field UIDs (WordPress entries are flat). */
 const FLAT_PAYLOAD_SKIP = new Set([
     'uid',
@@ -155,8 +181,8 @@ const mergeFlatPayloadIntoEntry = async (entry, entryUid, updateData, oldMapping
                 oldMapping,
                 newMapping
             );
-        } else if (isReferenceValue(nextVal) || isReferenceArray(nextVal)) {
-            nextVal = resolveReferenceField(field, entryUid, nextVal, locale, entryMapping);
+        } else {
+            nextVal = resolveReferencesDeep(field, entryUid, nextVal, locale, entryMapping);
         }
         entry.content[field] = nextVal;
     }
@@ -259,8 +285,8 @@ module.exports = async ({
                                             oldMapping,
                                             newMapping
                                         );
-                                    } else if (isReferenceValue(updateData?.content[field]) || isReferenceArray(updateData?.content[field])) {
-                                        updateData.content[field] = resolveReferenceField(
+                                    } else {
+                                        updateData.content[field] = resolveReferencesDeep(
                                             field,
                                             entryUid,
                                             updateData?.content[field],
@@ -286,8 +312,8 @@ module.exports = async ({
                                                 oldMapping,
                                                 newMapping
                                             );
-                                        } else if (isReferenceValue(updateData[field]) || isReferenceArray(updateData[field])) {
-                                            updateData[field] = resolveReferenceField(
+                                        } else {
+                                            updateData[field] = resolveReferencesDeep(
                                                 field,
                                                 entryUid,
                                                 updateData[field],
@@ -329,3 +355,4 @@ module.exports.isReferenceValue = isReferenceValue;
 module.exports.isReferenceArray = isReferenceArray;
 module.exports.resolveReferenceUid = resolveReferenceUid;
 module.exports.resolveReferenceField = resolveReferenceField;
+module.exports.resolveReferencesDeep = resolveReferencesDeep;

--- a/api/src/utils/entry-update-script.cjs
+++ b/api/src/utils/entry-update-script.cjs
@@ -9,8 +9,13 @@ const isReferenceValue = (value) =>
     value && typeof value === 'object' && !Array.isArray(value) &&
     'uid' in value && '_content_type_uid' in value;
 
+// Loosened from `.every(...)` to `.some(...)`: producers can legitimately emit mixed arrays
+// — `processArrayFields` (contentful.service.ts) pushes the raw Contentful Link object when
+// the target isn't in the references map, and the single-reference path can inject
+// `[undefined]` — so one non-reference element would otherwise disable resolution for the
+// whole field. Per-item remap happens in resolveReferenceField.
 const isReferenceArray = (value) =>
-    Array.isArray(value) && value.length > 0 && value.every(isReferenceValue);
+    Array.isArray(value) && value.length > 0 && value.some(isReferenceValue);
 
 /**
  * Resolves a source-side entry uid to its real Contentstack destination uid.
@@ -53,7 +58,11 @@ const resolveReferenceField = (fieldName, entryUid, value, locale, entryMapping)
         return { ...value, uid: resolved };
     }
     if (isReferenceArray(value)) {
+        // Pass non-reference items through untouched so a stray non-link element (e.g. a raw
+        // Contentful link that wasn't in the references map, or `undefined` from an earlier
+        // failed resolve) doesn't crash and doesn't corrupt neighboring references.
         return value.map((item) => {
+            if (!isReferenceValue(item)) return item;
             const resolved = resolveReferenceUid(item.uid, locale, entryMapping);
             return { ...item, uid: resolved };
         });

--- a/api/src/utils/entry-update-script.cjs
+++ b/api/src/utils/entry-update-script.cjs
@@ -4,6 +4,63 @@ const isAssetField = (value) =>
     value && typeof value === 'object' && !Array.isArray(value) &&
     'urlPath' in value && 'filename' in value;
 
+/** Shape produced by processField's 'reference' case: { uid, _content_type_uid }. */
+const isReferenceValue = (value) =>
+    value && typeof value === 'object' && !Array.isArray(value) &&
+    'uid' in value && '_content_type_uid' in value;
+
+const isReferenceArray = (value) =>
+    Array.isArray(value) && value.length > 0 && value.every(isReferenceValue);
+
+/**
+ * Resolves a source-side entry uid to its real Contentstack destination uid.
+ *
+ * The export JSON's reference fields carry the SOURCE cms entry id (see
+ * `contentful.service.ts`'s `createRefrence`), which only happens to equal the
+ * Contentstack uid when entries are imported preserving source ids. The
+ * bulk/master-locale import resolves this correctly via the CLI's own
+ * reference pass; this update path does not, so it needs the same uid-mapper
+ * data the asset resolution above already uses (see `entryMapping`).
+ *
+ * Preference order: per-locale mapping (most precise — handles entries that
+ * ended up as distinct Contentstack uids per locale across iterations) →
+ * flat mapping → identity fallback (keeps existing behavior when no mapping
+ * data exists, e.g. simple setups where source id equals destination uid).
+ */
+const resolveReferenceUid = (sourceUid, locale, entryMapping) => {
+    if (!sourceUid) return sourceUid;
+    const newByLocale = entryMapping?.new?.byLocale?.[locale]?.[sourceUid];
+    if (newByLocale) return newByLocale;
+    const oldByLocale = entryMapping?.old?.byLocale?.[locale]?.[sourceUid];
+    if (oldByLocale) return oldByLocale;
+    const newFlat = entryMapping?.new?.flat?.[sourceUid];
+    if (newFlat) return newFlat;
+    const oldFlat = entryMapping?.old?.flat?.[sourceUid];
+    if (oldFlat) return oldFlat;
+    return sourceUid;
+};
+
+/**
+ * Remaps the uid(s) inside a reference field value (single link object or
+ * array of link objects) to their Contentstack destination uids.
+ */
+const resolveReferenceField = (fieldName, entryUid, value, locale, entryMapping) => {
+    if (isReferenceValue(value)) {
+        const resolved = resolveReferenceUid(value.uid, locale, entryMapping);
+        if (resolved !== value.uid) {
+            console.info(`[${entryUid}] "${fieldName}"${locale ? ` (${locale})` : ''}: resolved reference uid "${value.uid}" → "${resolved}"`);
+        }
+        return { ...value, uid: resolved };
+    }
+    if (isReferenceArray(value)) {
+        return value.map((item) => {
+            const resolved = resolveReferenceUid(item.uid, locale, entryMapping);
+            return { ...item, uid: resolved };
+        });
+    }
+    return value;
+};
+
 /** Export JSON metadata — not Contentstack content-type field UIDs (WordPress entries are flat). */
 const FLAT_PAYLOAD_SKIP = new Set([
     'uid',
@@ -68,7 +125,7 @@ const resolveAssetField = (fieldName, entryUid, updateValue, stackValue, oldMapp
  * WordPress (and similar) write migration JSON with fields at the root (email, url, …).
  * Fetched stack entries keep custom fields under entry.content — merge flat updateData there.
  */
-const mergeFlatPayloadIntoEntry = async (entry, entryUid, updateData, oldMapping, newMapping, updateOpts) => {
+const mergeFlatPayloadIntoEntry = async (entry, entryUid, updateData, oldMapping, newMapping, updateOpts, locale, entryMapping) => {
     for (const field of Object.keys(updateData)) {
         if (FLAT_PAYLOAD_SKIP.has(field)) {
             continue;
@@ -89,6 +146,8 @@ const mergeFlatPayloadIntoEntry = async (entry, entryUid, updateData, oldMapping
                 oldMapping,
                 newMapping
             );
+        } else if (isReferenceValue(nextVal) || isReferenceArray(nextVal)) {
+            nextVal = resolveReferenceField(field, entryUid, nextVal, locale, entryMapping);
         }
         entry.content[field] = nextVal;
     }
@@ -103,6 +162,9 @@ module.exports = async ({
     const assetMapping = config.__assetMapping__ || { old: {}, new: {} };
     delete config.__assetMapping__;
 
+    const entryMapping = config.__entryMapping__ || { old: { flat: {}, byLocale: {} }, new: { flat: {}, byLocale: {} } };
+    delete config.__entryMapping__;
+
     // Assets the user chose to update in place (same UID, new file).
     const assetUpdates = Array.isArray(config.__assetUpdates__) ? config.__assetUpdates__ : [];
     delete config.__assetUpdates__;
@@ -110,6 +172,7 @@ module.exports = async ({
     const oldMapping = assetMapping.old || {};
     const newMapping = assetMapping.new || {};
     console.info(`Asset mappings loaded — old: ${Object.keys(oldMapping).length}, new: ${Object.keys(newMapping).length}`);
+    console.info(`Entry mappings loaded — old: ${Object.keys(entryMapping?.old?.flat || {}).length} flat / ${Object.keys(entryMapping?.old?.byLocale || {}).length} locales, new: ${Object.keys(entryMapping?.new?.flat || {}).length} flat / ${Object.keys(entryMapping?.new?.byLocale || {}).length} locales`);
     console.info(`Asset updates to replace in place: ${assetUpdates.length}`);
 
     const contentTypes = Object.keys(config);
@@ -187,13 +250,21 @@ module.exports = async ({
                                             oldMapping,
                                             newMapping
                                         );
+                                    } else if (isReferenceValue(updateData?.content[field]) || isReferenceArray(updateData?.content[field])) {
+                                        updateData.content[field] = resolveReferenceField(
+                                            field,
+                                            entryUid,
+                                            updateData?.content[field],
+                                            locale,
+                                            entryMapping
+                                        );
                                     }
                                 }
                                 Object.assign(entry?.content, updateData?.content);
                                 await entry.update(updateOpts);
                             } else if (hasStackContent) {
                                 console.info(`[${realEntryUid}] Merging flat migration payload into entry.content (e.g. WordPress export)${locale ? ` for locale "${locale}"` : ''}`);
-                                await mergeFlatPayloadIntoEntry(entry, realEntryUid, updateData, oldMapping, newMapping, updateOpts);
+                                await mergeFlatPayloadIntoEntry(entry, realEntryUid, updateData, oldMapping, newMapping, updateOpts, locale, entryMapping);
                             } else {
                                 if (updateData && entry) {
                                     for (const field of Object.keys(updateData)) {
@@ -205,6 +276,14 @@ module.exports = async ({
                                                 entry[field],
                                                 oldMapping,
                                                 newMapping
+                                            );
+                                        } else if (isReferenceValue(updateData[field]) || isReferenceArray(updateData[field])) {
+                                            updateData[field] = resolveReferenceField(
+                                                field,
+                                                entryUid,
+                                                updateData[field],
+                                                locale,
+                                                entryMapping
                                             );
                                         }
                                     }
@@ -237,3 +316,7 @@ module.exports = async ({
 module.exports.isAssetField = isAssetField;
 module.exports.resolveAssetField = resolveAssetField;
 module.exports.mergeFlatPayloadIntoEntry = mergeFlatPayloadIntoEntry;
+module.exports.isReferenceValue = isReferenceValue;
+module.exports.isReferenceArray = isReferenceArray;
+module.exports.resolveReferenceUid = resolveReferenceUid;
+module.exports.resolveReferenceField = resolveReferenceField;

--- a/api/src/utils/entry-update-script.cjs
+++ b/api/src/utils/entry-update-script.cjs
@@ -80,9 +80,15 @@ const resolveReferenceField = (fieldName, entryUid, value, locale, entryMapping)
  * rewrites reference shapes, nothing else.
  */
 const resolveReferencesDeep = (fieldName, entryUid, value, locale, entryMapping) => {
-    if (isReferenceValue(value) || isReferenceArray(value)) {
+    if (isReferenceValue(value)) {
         return resolveReferenceField(fieldName, entryUid, value, locale, entryMapping);
     }
+    // Recurse per-element rather than delegating the whole array to isReferenceArray +
+    // resolveReferenceField's shallow array handling. That shallow path only remaps
+    // elements matching isReferenceValue and passes everything else through byte-for-byte
+    // — so a MIXED array (a bare reference next to an object with a reference nested
+    // inside, e.g. a modular-block array) would leave the nested one unresolved. Recursing
+    // into every element here — reference, container, or scalar — covers that case too.
     if (Array.isArray(value)) {
         return value.map((item) => resolveReferencesDeep(fieldName, entryUid, item, locale, entryMapping));
     }

--- a/api/src/utils/entry-update.utils.ts
+++ b/api/src/utils/entry-update.utils.ts
@@ -298,6 +298,64 @@ export const enrichConfigWithAssetMapping = (
 };
 
 /**
+ * Reads old (previous iteration) and new (current iteration) entry uid mappings
+ * — both the flat source→dest map and the per-locale map written by
+ * `writePerLocaleEntryUidMapping` — and merges them into the updated-entries
+ * config file under `__entryMapping__`.
+ *
+ * This lets the entry-update-script resolve Link(Entry)/reference field values
+ * to their real Contentstack destination uid before writing them onto a
+ * localized (non-master) copy of an entry. Without this, reference fields
+ * written during a locale-add restart keep the export's source-side uid,
+ * which only happens to work when source and destination uids are identical —
+ * the master-locale bulk import resolves this correctly via the Contentstack
+ * CLI's own reference pass, but this update path does not, unless we prime it
+ * with the same uid-mapper data (mirrors `enrichConfigWithAssetMapping`).
+ */
+export const enrichConfigWithEntryMapping = (
+    configFilePath: string,
+    projectId: string,
+    iteration: number,
+    loggerPath?: string
+): void => {
+    const dbBase = path.join(process.cwd(), DATABASE_FILES.DIRECTORY, projectId);
+
+    const readEntryMapper = (iter: number): { flat: Record<string, string>; byLocale: Record<string, Record<string, string>> } => {
+        const p = path.join(dbBase, iter.toString(), DATABASE_FILES.UID_MAPPER);
+        if (!fs.existsSync(p)) return { flat: {}, byLocale: {} };
+        try {
+            const data = JSON.parse(fs.readFileSync(p, "utf-8"));
+            return { flat: data?.entry || {}, byLocale: data?.entryByLocale || {} };
+        } catch (err) {
+            console.error(`Failed to read uid-mapper for iteration ${iter}:`, err);
+            return { flat: {}, byLocale: {} };
+        }
+    };
+
+    const oldEntryMapping = iteration > 1 ? readEntryMapper(iteration - 1) : { flat: {}, byLocale: {} };
+    const newEntryMapping = readEntryMapper(iteration);
+
+    writeLogEntry(
+        `Loaded entry uid mappings — old: ${Object.keys(oldEntryMapping.flat).length} flat / ${Object.keys(oldEntryMapping.byLocale).length} locales, ` +
+        `new: ${Object.keys(newEntryMapping.flat).length} flat / ${Object.keys(newEntryMapping.byLocale).length} locales`,
+        "enrichConfigWithEntryMapping",
+        loggerPath,
+    );
+
+    try {
+        const config = JSON.parse(fs.readFileSync(configFilePath, "utf-8"));
+        config.__entryMapping__ = { old: oldEntryMapping, new: newEntryMapping };
+        fs.writeFileSync(configFilePath, JSON.stringify(config), "utf-8");
+    } catch (err) {
+        console.error("Failed to write entry mapping into update config:", err);
+        writeLogEntry(`Failed to write __entryMapping__ into ${configFilePath}: ${(err as Error)?.message}`, "enrichConfigWithEntryMapping", loggerPath);
+        return;
+    }
+
+    writeLogEntry(`Entry mapping enriched into config for iteration ${iteration}`, "enrichConfigWithEntryMapping", loggerPath);
+};
+
+/**
  * Ensures an update config file exists for this iteration and returns its path.
  * Used when there are asset updates but no entry updates produced a config, so
  * the update CLI still has a file to drive the asset-replace task.

--- a/api/src/utils/entry-update.utils.ts
+++ b/api/src/utils/entry-update.utils.ts
@@ -9,6 +9,7 @@ import {
     getSourceLocaleForDestination,
 } from "./locale-migration.utils.js";
 import type { AssetUpdate } from "./asset-update.utils.js";
+import { flattenNestedUidMap } from "./uid-mapper.utils.js";
 
 /**
  * Helper function to write log entries to file
@@ -325,7 +326,17 @@ export const enrichConfigWithEntryMapping = (
         if (!fs.existsSync(p)) return { flat: {}, byLocale: {} };
         try {
             const data = JSON.parse(fs.readFileSync(p, "utf-8"));
-            return { flat: data?.entry || {}, byLocale: data?.entryByLocale || {} };
+            // Uid-mapper's `entry` key can be either the flat `{ sourceUid: destUid }` shape
+            // or the nested `{ [ctUid]: { sourceUid: destUid } }` shape (see
+            // uid-mapper.utils.ts:mergeUidMaps). contentMapper.service also merges in an
+            // `entryUid` variant — do the same here so both readers stay in sync and the
+            // resolver never silently falls through to the identity fallback.
+            const fromEntry = flattenNestedUidMap(data?.entry);
+            const fromEntryUid = flattenNestedUidMap(data?.entryUid);
+            return {
+                flat: { ...fromEntry, ...fromEntryUid },
+                byLocale: data?.entryByLocale || {},
+            };
         } catch (err) {
             console.error(`Failed to read uid-mapper for iteration ${iter}:`, err);
             return { flat: {}, byLocale: {} };

--- a/api/src/utils/locale-migration.utils.ts
+++ b/api/src/utils/locale-migration.utils.ts
@@ -65,6 +65,38 @@ export const isFullMigrationForLocale = (
 };
 
 /**
+ * Extracts destination locale codes that were ACTUALLY targeted by a delta
+ * run, from an `updated-entries.json` config object.
+ *
+ * Per-entry keys in that config are `${csUid}::${localeCode}` (see
+ * `removeEntriesFromDatabase` in entry-update.utils.ts) — this reads the
+ * locale suffix back out. Bookkeeping keys added by the enrich* helpers
+ * (`__assetMapping__`, `__entryMapping__`, `__assetUpdates__`) are skipped.
+ *
+ * This exists to fix a bug where a locale got marked "migrated" as soon as
+ * ANY locale finished a delta run, instead of only the locale(s) that run
+ * actually processed — which permanently skipped locales configured ahead of
+ * when they were meant to be migrated (see `runCli.service.ts`).
+ */
+export const extractLocalesFromUpdateConfig = (
+  config: Record<string, any> | null | undefined,
+): string[] => {
+  if (!config || typeof config !== 'object') return [];
+  const locales = new Set<string>();
+  for (const [ctKey, entries] of Object.entries(config)) {
+    if (ctKey.startsWith('__')) continue;
+    if (!entries || typeof entries !== 'object') continue;
+    for (const entryKey of Object.keys(entries)) {
+      const sep = entryKey.lastIndexOf('::');
+      if (sep === -1) continue;
+      const locale = entryKey.slice(sep + 2);
+      if (locale) locales.add(locale);
+    }
+  }
+  return Array.from(locales);
+};
+
+/**
  * Set-union the given locales into project.migrated_locales and persist.
  * Idempotent.
  */

--- a/api/src/utils/uid-mapper.utils.ts
+++ b/api/src/utils/uid-mapper.utils.ts
@@ -6,6 +6,28 @@ import fs from "fs";
 import projectModelLowdb from "../models/project-lowdb";
 
 /**
+ * Normalises a uid map that may be either flat `{ sourceUid: destUid }` or nested
+ * per-content-type `{ [ctUid]: { sourceUid: destUid } }` into a single flat map.
+ * If ANY top-level value is a non-array object, we treat the whole map as nested
+ * and merge the second-level objects; otherwise the input is passed through.
+ * Kept in this module so both entry-mapping consumers (`contentMapper.service`
+ * and `entry-update.utils`) share one authoritative implementation.
+ */
+export const flattenNestedUidMap = (raw: Record<string, any> | undefined | null): Record<string, any> => {
+  const keys = Object?.keys(raw ?? {});
+  if (keys?.length === 0) return {};
+  const nested = keys?.every((k) => {
+    const v = (raw as Record<string, any>)[k];
+    return v != null && typeof v === 'object' && !Array.isArray(v);
+  });
+  if (!nested) return { ...(raw as Record<string, any>) };
+  return keys.reduce<Record<string, any>>(
+    (acc, k) => ({ ...acc, ...(raw as Record<string, any>)[k] }),
+    {},
+  );
+};
+
+/**
  * Merges a previous iteration's uid map under the current run's map (current
  * wins on conflict). Values can be plain strings (flat old→new maps) or
  * one-level nested objects (per-content-type entry maps) — nested objects are

--- a/api/src/utils/uid-mapper.utils.ts
+++ b/api/src/utils/uid-mapper.utils.ts
@@ -8,23 +8,26 @@ import projectModelLowdb from "../models/project-lowdb";
 /**
  * Normalises a uid map that may be either flat `{ sourceUid: destUid }` or nested
  * per-content-type `{ [ctUid]: { sourceUid: destUid } }` into a single flat map.
- * If ANY top-level value is a non-array object, we treat the whole map as nested
- * and merge the second-level objects; otherwise the input is passed through.
+ * Checked per-key rather than all-or-nothing, so a MIXED map (some flat string
+ * values, some nested objects — which mergeUidMaps below can produce when a prior
+ * iteration stored the flat shape and the current run wrote the nested one) is
+ * handled correctly: nested keys get unpacked, flat keys pass through as-is.
  * Kept in this module so both entry-mapping consumers (`contentMapper.service`
  * and `entry-update.utils`) share one authoritative implementation.
  */
 export const flattenNestedUidMap = (raw: Record<string, any> | undefined | null): Record<string, any> => {
   const keys = Object?.keys(raw ?? {});
   if (keys?.length === 0) return {};
-  const nested = keys?.every((k) => {
+  const out: Record<string, any> = {};
+  for (const k of keys) {
     const v = (raw as Record<string, any>)[k];
-    return v != null && typeof v === 'object' && !Array.isArray(v);
-  });
-  if (!nested) return { ...(raw as Record<string, any>) };
-  return keys.reduce<Record<string, any>>(
-    (acc, k) => ({ ...acc, ...(raw as Record<string, any>)[k] }),
-    {},
-  );
+    if (v != null && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(out, v);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
 };
 
 /**

--- a/api/tests/unit/routes/contentMapper.routes.test.ts
+++ b/api/tests/unit/routes/contentMapper.routes.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../../src/controllers/projects.contentMapper.controller.js', () => (
     getSingleGlobalField: vi.fn((_req: any, res: any) => res.status(200).json({})),
     getAssetMapping: vi.fn((_req: any, res: any) => res.status(200).json({})),
     updateAssetStatus: vi.fn((_req: any, res: any) => res.status(200).json({})),
+    retryAssetDownload: vi.fn((_req: any, res: any) => res.status(200).json({})),
   },
 }));
 

--- a/api/tests/unit/services/contentMapper.service.test.ts
+++ b/api/tests/unit/services/contentMapper.service.test.ts
@@ -22,6 +22,11 @@ const {
   mockUidMapperDb,
   getEntryMapperDbMock,
   getUidMapperDbMock,
+  mockRetryFailedAsset,
+  mockAssetMapperDb,
+  getAssetMapperDbMock,
+  mockFsExistsSync,
+  mockFsReadFileSync,
 } = vi.hoisted(() => {
   const mockContentTypesMapperRead = vi.fn();
   const mockContentTypesMapperUpdate = vi.fn();
@@ -63,6 +68,13 @@ const {
     chain: { get: mockUidMapperChainGet },
     data: { entry: {} as Record<string, unknown>, assets: {} as Record<string, unknown> },
   };
+  const mockAssetMapperRead = vi.fn();
+  const mockAssetMapperChainGet = vi.fn();
+  const mockAssetMapperDb = {
+    read: mockAssetMapperRead,
+    chain: { get: mockAssetMapperChainGet },
+    data: { asset_mapper: [] as unknown[] },
+  };
   return {
     mockHttps: vi.fn(),
     mockGetAuthToken: vi.fn(),
@@ -85,6 +97,11 @@ const {
     mockUidMapperDb,
     getEntryMapperDbMock: vi.fn(() => mockEntryMapperDb),
     getUidMapperDbMock: vi.fn(() => mockUidMapperDb),
+    mockRetryFailedAsset: vi.fn(),
+    mockAssetMapperDb,
+    getAssetMapperDbMock: vi.fn(() => mockAssetMapperDb),
+    mockFsExistsSync: vi.fn(() => false),
+    mockFsReadFileSync: vi.fn(() => '{}'),
   };
 });
 
@@ -131,11 +148,26 @@ vi.mock('../../../src/models/uidMapper.js', () => ({
   default: getUidMapperDbMock,
 }));
 
+vi.mock('../../../src/models/assetMapper.js', () => ({
+  default: getAssetMapperDbMock,
+}));
+
+vi.mock('../../../src/services/contentful.service.js', () => ({
+  contentfulService: { retryFailedAsset: mockRetryFailedAsset },
+}));
+
 vi.mock('fs', () => {
   const mkdirSync = vi.fn();
   return {
-    default: { promises: mockFsPromises, mkdirSync },
+    default: {
+      promises: mockFsPromises,
+      mkdirSync,
+      existsSync: mockFsExistsSync,
+      readFileSync: mockFsReadFileSync,
+    },
     mkdirSync,
+    existsSync: mockFsExistsSync,
+    readFileSync: mockFsReadFileSync,
     promises: mockFsPromises,
   };
 });
@@ -147,13 +179,15 @@ const createChain = (opts: {
   find?: unknown;
   findIndex?: number;
   value?: unknown;
+  filter?: unknown[];
 }) => {
   const findValue = opts.find !== undefined ? opts.find : null;
   const findIndexValue = opts.findIndex !== undefined ? opts.findIndex : -1;
+  const filterValue = opts.filter !== undefined ? opts.filter : [];
   return {
     find: vi.fn().mockReturnValue({ value: vi.fn().mockReturnValue(findValue) }),
     findIndex: vi.fn().mockReturnValue({ value: vi.fn().mockReturnValue(findIndexValue) }),
-    filter: vi.fn().mockReturnValue({ value: vi.fn().mockReturnValue([]) }),
+    filter: vi.fn().mockReturnValue({ value: vi.fn().mockReturnValue(filterValue) }),
   };
 };
 
@@ -165,12 +199,16 @@ describe('contentMapper.service', () => {
     (mockFieldDb.chain.get as ReturnType<typeof vi.fn>).mockReset();
     (mockEntryMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReset();
     (mockUidMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReset();
+    (mockAssetMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReset();
     mockGetAuthToken.mockResolvedValue('cs-auth-token');
     mockProjectRead.mockResolvedValue(undefined);
     mockContentTypesMapperRead.mockResolvedValue(undefined);
     mockFieldMapperRead.mockResolvedValue(undefined);
     (mockEntryMapperDb.read as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     (mockUidMapperDb.read as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (mockAssetMapperDb.read as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    mockFsExistsSync.mockReturnValue(false);
+    mockFsReadFileSync.mockReturnValue('{}');
     mockProjectUpdate.mockImplementation(async (fn: (d: any) => void) => {
       const data = ProjectModelLowdb.data as any;
       if (!data.projects) data.projects = [];
@@ -202,11 +240,13 @@ describe('contentMapper.service', () => {
     mockFieldDb.data = { field_mapper: [] };
     mockEntryMapperDb.data = { entry_mapper: [] };
     mockUidMapperDb.data = { entry: {}, assets: {} };
+    mockAssetMapperDb.data = { asset_mapper: [] };
     (ProjectModelLowdb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(createChain({ find: null, findIndex: -1 }));
     (mockContentTypesDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(createChain({ find: null, findIndex: -1 }));
     (mockFieldDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(createChain({ find: null, findIndex: -1 }));
     (mockEntryMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(createChain({ find: null, findIndex: -1 }));
     (mockUidMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(createChain({ find: null, findIndex: -1 }));
+    (mockAssetMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(createChain({ filter: [] }));
   });
 
   describe('putTestData', () => {
@@ -885,6 +925,193 @@ describe('contentMapper.service', () => {
 
       expect(result.status).toBe(404);
       expect(result.data).toBe('Project not found');
+    });
+  });
+
+  describe('retryAssetDownload', () => {
+    it('returns 400 when assetUid is missing', async () => {
+      const req = { params: { projectId: 'proj-1' } } as any;
+
+      const result = await contentMapperService.retryAssetDownload(req);
+
+      expect(result.status).toBe(400);
+      expect(result.data.message).toMatch(/assetUid/i);
+    });
+
+    it('returns 400 when the project has no destination stack or source file path', async () => {
+      const project = { id: 'proj-1', legacy_cms: { cms: 'contentful' } };
+      (ProjectModelLowdb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({ find: project })
+      );
+
+      const req = { params: { projectId: 'proj-1', assetUid: 'src-1' } } as any;
+      const result = await contentMapperService.retryAssetDownload(req);
+
+      expect(result.status).toBe(400);
+      expect(result.data.message).toMatch(/destination stack|source file/i);
+    });
+
+    it('returns 400 for a non-Contentful project', async () => {
+      const project = {
+        id: 'proj-1',
+        destination_stack_id: 'stack-1',
+        legacy_cms: { cms: 'wordpress', file_path: '/tmp/export.xml' },
+      };
+      (ProjectModelLowdb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({ find: project })
+      );
+
+      const req = { params: { projectId: 'proj-1', assetUid: 'src-1' } } as any;
+      const result = await contentMapperService.retryAssetDownload(req);
+
+      expect(result.status).toBe(400);
+      expect(result.data.message).toMatch(/Contentful/i);
+    });
+
+    it('returns 200 with success:true when the retry succeeds', async () => {
+      const project = {
+        id: 'proj-1',
+        destination_stack_id: 'stack-1',
+        legacy_cms: { cms: 'contentful', file_path: '/tmp/export.json' },
+      };
+      (ProjectModelLowdb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({ find: project })
+      );
+      mockRetryFailedAsset.mockResolvedValue({
+        success: true,
+        message: 'Asset downloaded successfully. It will be included in the next migration run.',
+      });
+
+      const req = { params: { projectId: 'proj-1', assetUid: 'src-1' } } as any;
+      const result = await contentMapperService.retryAssetDownload(req);
+
+      expect(mockRetryFailedAsset).toHaveBeenCalledWith('/tmp/export.json', 'stack-1', 'proj-1', 'src-1');
+      expect(result.status).toBe(200);
+      expect(result.data.success).toBe(true);
+    });
+
+    it('returns 400 with the failure reason when the retry fails again', async () => {
+      const project = {
+        id: 'proj-1',
+        destination_stack_id: 'stack-1',
+        legacy_cms: { cms: 'contentful', file_path: '/tmp/export.json' },
+      };
+      (ProjectModelLowdb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({ find: project })
+      );
+      mockRetryFailedAsset.mockResolvedValue({ success: false, message: 'DNS lookup failed.' });
+
+      const req = { params: { projectId: 'proj-1', assetUid: 'src-1' } } as any;
+      const result = await contentMapperService.retryAssetDownload(req);
+
+      expect(result.status).toBe(400);
+      expect(result.data.success).toBe(false);
+      expect(result.data.message).toBe('DNS lookup failed.');
+    });
+  });
+
+  describe('getAssetMapping', () => {
+    const project = { id: 'proj-1', destination_stack_id: 'stack1', iteration: 1 };
+    const baseReq = (overrides: Record<string, unknown> = {}) =>
+      ({
+        params: { projectId: 'proj-1', skip: '0', limit: '10', searchText: '', ...overrides },
+        query: {},
+      }) as any;
+
+    beforeEach(() => {
+      (ProjectModelLowdb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({ find: project })
+      );
+    });
+
+    it('returns assets with an ok status when nothing failed', async () => {
+      (mockAssetMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({
+          filter: [
+            { projectId: 'proj-1', otherCmsAssetUid: 'src-1', contentstackAssetUid: 'cs-1', filename: 'a.jpg', title: 'A' },
+          ],
+        })
+      );
+
+      const result = await contentMapperService.getAssetMapping(baseReq());
+
+      expect(result.status).toBe(200);
+      expect(result.count).toBe(1);
+      expect(result.assetMapping[0].status).toBe('ok');
+      expect(result.missingCount).toBe(0);
+      expect(result.failedCount).toBe(0);
+    });
+
+    it('marks assets with no source file as missing', async () => {
+      (mockAssetMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({
+          filter: [
+            { projectId: 'proj-1', otherCmsAssetUid: 'src-2', hasSource: false, filename: 'b.jpg', title: 'B' },
+          ],
+        })
+      );
+
+      const result = await contentMapperService.getAssetMapping(baseReq());
+
+      expect(result.assetMapping[0].status).toBe('missing');
+      expect(result.missingCount).toBe(1);
+    });
+
+    it('marks assets recorded in cs_failed.json as failed', async () => {
+      (mockAssetMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({
+          filter: [
+            { projectId: 'proj-1', otherCmsAssetUid: 'src-3', filename: 'c.jpg', title: 'C' },
+          ],
+        })
+      );
+      mockFsExistsSync.mockReturnValue(true);
+      mockFsReadFileSync.mockReturnValue(
+        JSON.stringify({ 'src-3': { reason_for_error: 'Timeout downloading asset.' } })
+      );
+
+      const result = await contentMapperService.getAssetMapping(baseReq());
+
+      expect(result.assetMapping[0].status).toBe('failed');
+      expect(result.assetMapping[0].errorMessage).toBe('Timeout downloading asset.');
+      expect(result.failedCount).toBe(1);
+    });
+
+    it('filters by the requested status', async () => {
+      (mockAssetMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({
+          filter: [
+            { projectId: 'proj-1', otherCmsAssetUid: 'src-1', contentstackAssetUid: 'cs-1', filename: 'a.jpg', title: 'A' },
+            { projectId: 'proj-1', otherCmsAssetUid: 'src-2', hasSource: false, filename: 'b.jpg', title: 'B' },
+          ],
+        })
+      );
+
+      const result = await contentMapperService.getAssetMapping(baseReq({}));
+      const filteredResult = await contentMapperService.getAssetMapping({
+        params: { projectId: 'proj-1', skip: '0', limit: '10', searchText: '' },
+        query: { status: 'missing' },
+      } as any);
+
+      expect(result.count).toBe(2);
+      expect(filteredResult.count).toBe(1);
+      expect(filteredResult.assetMapping[0].status).toBe('missing');
+    });
+
+    it('filters by search text against filename and title', async () => {
+      (mockAssetMapperDb.chain.get as ReturnType<typeof vi.fn>).mockReturnValue(
+        createChain({
+          filter: [
+            { projectId: 'proj-1', otherCmsAssetUid: 'src-1', contentstackAssetUid: 'cs-1', filename: 'windmill.jpg', title: 'Windmill' },
+            { projectId: 'proj-1', otherCmsAssetUid: 'src-2', contentstackAssetUid: 'cs-2', filename: 'sunset.jpg', title: 'Sunset' },
+          ],
+        })
+      );
+
+      const result = await contentMapperService.getAssetMapping(baseReq({ searchText: 'wind' }));
+
+      expect(result.count).toBe(1);
+      expect(result.assetMapping[0].filename).toBe('windmill.jpg');
     });
   });
 });

--- a/api/tests/unit/services/contentful.service.retryFailedAsset.test.ts
+++ b/api/tests/unit/services/contentful.service.retryFailedAsset.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../src/utils/custom-logger.utils.js', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { contentfulService } = await import('../../../src/services/contentful.service.js');
+
+describe('contentfulService.retryFailedAsset', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns failure when the asset is not present in the source export', async () => {
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(
+      JSON.stringify({ assets: [{ sys: { id: 'some-other-asset' } }] }),
+    );
+
+    const result = await contentfulService.retryFailedAsset(
+      '/fake/package/path.json',
+      'stack123',
+      'project123',
+      'missing-asset-id',
+    );
+
+    expect(result).toEqual({
+      success: false,
+      message: 'Asset not found in the source export.',
+    });
+  });
+
+  it('returns a failure message when reading the package file throws', async () => {
+    vi.spyOn(fs.promises, 'readFile').mockRejectedValue(new Error('ENOENT: no such file'));
+
+    const result = await contentfulService.retryFailedAsset(
+      '/fake/package/path.json',
+      'stack123',
+      'project123',
+      'asset-id',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('ENOENT');
+  });
+});

--- a/api/tests/unit/utils/entry-update-script.test.ts
+++ b/api/tests/unit/utils/entry-update-script.test.ts
@@ -7,7 +7,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // default function export for testing.
 const require = createRequire(import.meta.url);
 const script = require('../../../src/utils/entry-update-script.cjs');
-const { isAssetField, resolveAssetField, mergeFlatPayloadIntoEntry } = script;
+const {
+  isAssetField,
+  resolveAssetField,
+  mergeFlatPayloadIntoEntry,
+  isReferenceValue,
+  isReferenceArray,
+  resolveReferenceUid,
+  resolveReferenceField,
+} = script;
 
 describe('entry-update-script — isAssetField', () => {
   it('is true only for objects carrying urlPath + filename', () => {
@@ -66,6 +74,91 @@ describe('entry-update-script — resolveAssetField (3-way resolution)', () => {
   });
 });
 
+describe('entry-update-script — isReferenceValue / isReferenceArray', () => {
+  it('recognizes the { uid, _content_type_uid } shape produced by processField', () => {
+    expect(isReferenceValue({ uid: 'src-1', _content_type_uid: 'author' })).toBe(true);
+  });
+
+  it('is false for asset shapes, primitives, and arrays', () => {
+    expect(isReferenceValue({ urlPath: '/x', filename: 'f.jpg' })).toBe(false);
+    expect(isReferenceValue(null)).toBeFalsy();
+    expect(isReferenceValue('str')).toBeFalsy();
+    expect(isReferenceValue([{ uid: 'a', _content_type_uid: 'b' }])).toBe(false);
+    expect(isReferenceValue({ uid: 'src-1' })).toBe(false); // missing _content_type_uid
+  });
+
+  it('recognizes a non-empty array of reference values (multi-reference field)', () => {
+    expect(isReferenceArray([{ uid: 'a', _content_type_uid: 'article' }, { uid: 'b', _content_type_uid: 'article' }])).toBe(true);
+  });
+
+  it('is false for an empty array or a mixed array', () => {
+    expect(isReferenceArray([])).toBe(false);
+    expect(isReferenceArray([{ uid: 'a', _content_type_uid: 'article' }, 'not-a-ref'])).toBe(false);
+  });
+});
+
+describe('entry-update-script — resolveReferenceUid', () => {
+  const locale = 'en-in';
+  const entryMapping = {
+    old: { flat: { 'src-1': 'cs-old-flat' }, byLocale: { 'en-in': { 'src-2': 'cs-old-locale' } } },
+    new: { flat: { 'src-3': 'cs-new-flat' }, byLocale: { 'en-in': { 'src-1': 'cs-new-locale' } } },
+  };
+
+  it('prefers the new per-locale mapping over everything else', () => {
+    expect(resolveReferenceUid('src-1', locale, entryMapping)).toBe('cs-new-locale');
+  });
+
+  it('falls back to the old per-locale mapping when no new per-locale entry exists', () => {
+    expect(resolveReferenceUid('src-2', locale, entryMapping)).toBe('cs-old-locale');
+  });
+
+  it('falls back to the flat new mapping when no per-locale entry exists at all', () => {
+    expect(resolveReferenceUid('src-3', locale, entryMapping)).toBe('cs-new-flat');
+  });
+
+  it('falls back to the flat old mapping as a last resort', () => {
+    const mapping = { old: { flat: { 'src-4': 'cs-old-flat-only' }, byLocale: {} }, new: { flat: {}, byLocale: {} } };
+    expect(resolveReferenceUid('src-4', locale, mapping)).toBe('cs-old-flat-only');
+  });
+
+  it('falls back to identity (source uid unchanged) when no mapping exists at all', () => {
+    expect(resolveReferenceUid('unmapped-src', locale, { old: { flat: {}, byLocale: {} }, new: { flat: {}, byLocale: {} } })).toBe('unmapped-src');
+  });
+
+  it('handles a missing/undefined entryMapping gracefully', () => {
+    expect(resolveReferenceUid('src-1', locale, undefined)).toBe('src-1');
+  });
+});
+
+describe('entry-update-script — resolveReferenceField', () => {
+  const locale = 'en-gb';
+  const entryMapping = { old: { flat: {}, byLocale: {} }, new: { flat: {}, byLocale: { 'en-gb': { 'author-src': 'author-cs' } } } };
+
+  it('remaps a single reference value uid', () => {
+    const out = resolveReferenceField('author', 'e1', { uid: 'author-src', _content_type_uid: 'author' }, locale, entryMapping);
+    expect(out).toEqual({ uid: 'author-cs', _content_type_uid: 'author' });
+  });
+
+  it('remaps every uid in a multi-reference array', () => {
+    const mapping = { old: { flat: {}, byLocale: {} }, new: { flat: {}, byLocale: { 'en-gb': { a1: 'a1-cs', a2: 'a2-cs' } } } };
+    const out = resolveReferenceField(
+      'relatedArticles',
+      'e1',
+      [{ uid: 'a1', _content_type_uid: 'article' }, { uid: 'a2', _content_type_uid: 'article' }],
+      locale,
+      mapping
+    );
+    expect(out).toEqual([
+      { uid: 'a1-cs', _content_type_uid: 'article' },
+      { uid: 'a2-cs', _content_type_uid: 'article' },
+    ]);
+  });
+
+  it('passes non-reference values through unchanged', () => {
+    expect(resolveReferenceField('title', 'e1', 'plain string', locale, entryMapping)).toBe('plain string');
+  });
+});
+
 describe('entry-update-script — mergeFlatPayloadIntoEntry', () => {
   it('merges flat fields into entry.content, resolves assets, and skips reserved keys', async () => {
     const update = vi.fn().mockResolvedValue(undefined);
@@ -87,6 +180,40 @@ describe('entry-update-script — mergeFlatPayloadIntoEntry', () => {
     expect(entry.content.uid).toBeUndefined(); // reserved key skipped
     expect(entry.content._version).toBeUndefined();
     expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves a reference field uid using entryMapping when localizing an existing entry (CMG delta bug)', async () => {
+    // Reproduces the bug: an export's reference field carries the SOURCE cms
+    // entry id (e.g. Contentful's id), which only equals the Contentstack uid
+    // by coincidence. Without entryMapping this used to be written verbatim,
+    // silently pointing at a non-existent uid on any locale added via restart.
+    const update = vi.fn().mockResolvedValue(undefined);
+    const entry: any = { title: 'old', content: {}, update };
+
+    const updateData = {
+      uid: 'should-be-skipped',
+      title: 'Article 1',
+      author: { uid: 'contentful-author-src-id', _content_type_uid: 'author' },
+    };
+
+    const entryMapping = {
+      old: { flat: {}, byLocale: {} },
+      new: { flat: {}, byLocale: { 'en-in': { 'contentful-author-src-id': 'real-cs-author-uid' } } },
+    };
+
+    await mergeFlatPayloadIntoEntry(entry, 'e1', updateData, {}, {}, undefined, 'en-in', entryMapping);
+
+    expect(entry.content.author).toEqual({ uid: 'real-cs-author-uid', _content_type_uid: 'author' });
+  });
+
+  it('falls back to the source uid unchanged when no entryMapping is supplied (back-compat)', async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const entry: any = { title: 'old', content: {}, update };
+    const updateData = { author: { uid: 'src-id', _content_type_uid: 'author' } };
+
+    await mergeFlatPayloadIntoEntry(entry, 'e1', updateData, {}, {}, undefined, 'en-in', undefined);
+
+    expect(entry.content.author).toEqual({ uid: 'src-id', _content_type_uid: 'author' });
   });
 });
 

--- a/api/tests/unit/utils/entry-update-script.test.ts
+++ b/api/tests/unit/utils/entry-update-script.test.ts
@@ -91,9 +91,12 @@ describe('entry-update-script — isReferenceValue / isReferenceArray', () => {
     expect(isReferenceArray([{ uid: 'a', _content_type_uid: 'article' }, { uid: 'b', _content_type_uid: 'article' }])).toBe(true);
   });
 
-  it('is false for an empty array or a mixed array', () => {
+  it('is false for an empty array', () => {
     expect(isReferenceArray([])).toBe(false);
-    expect(isReferenceArray([{ uid: 'a', _content_type_uid: 'article' }, 'not-a-ref'])).toBe(false);
+  });
+
+  it('is true for a mixed array so per-item remap still runs — non-ref items pass through in resolveReferenceField', () => {
+    expect(isReferenceArray([{ uid: 'a', _content_type_uid: 'article' }, 'not-a-ref'])).toBe(true);
   });
 });
 

--- a/api/tests/unit/utils/entry-update-script.test.ts
+++ b/api/tests/unit/utils/entry-update-script.test.ts
@@ -15,6 +15,7 @@ const {
   isReferenceArray,
   resolveReferenceUid,
   resolveReferenceField,
+  resolveReferencesDeep,
 } = script;
 
 describe('entry-update-script — isAssetField', () => {
@@ -130,6 +131,53 @@ describe('entry-update-script — resolveReferenceUid', () => {
 
   it('handles a missing/undefined entryMapping gracefully', () => {
     expect(resolveReferenceUid('src-1', locale, undefined)).toBe('src-1');
+  });
+});
+
+describe('entry-update-script — resolveReferencesDeep', () => {
+  const locale = 'en-in';
+  const entryMapping = {
+    old: { flat: {}, byLocale: {} },
+    new: { flat: { 'src-1': 'cs-1', 'src-2': 'cs-2' }, byLocale: {} },
+  };
+
+  it('resolves a top-level reference value', () => {
+    const out = resolveReferencesDeep('field', 'entry-1', { uid: 'src-1', _content_type_uid: 'author' }, locale, entryMapping);
+    expect(out).toEqual({ uid: 'cs-1', _content_type_uid: 'author' });
+  });
+
+  it('resolves every reference nested inside a plain object (group field)', () => {
+    const value = { heroBlock: { author: { uid: 'src-1', _content_type_uid: 'author' } } };
+    const out = resolveReferencesDeep('field', 'entry-1', value, locale, entryMapping);
+    expect(out).toEqual({ heroBlock: { author: { uid: 'cs-1', _content_type_uid: 'author' } } });
+  });
+
+  it('resolves a MIXED array — a bare reference alongside an object with a reference nested inside', () => {
+    // Regression case: isReferenceArray's .some() used to route the whole array through
+    // resolveReferenceField's shallow per-item remap, which passes non-reference-shaped
+    // items through untouched — so the nested reference inside the block object never got
+    // resolved. resolveReferencesDeep must recurse into every element instead.
+    const value = [
+      { uid: 'src-1', _content_type_uid: 'author' },
+      { heroBlock: { uid: 'src-2', _content_type_uid: 'category' } },
+    ];
+    const out = resolveReferencesDeep('field', 'entry-1', value, locale, entryMapping);
+    expect(out).toEqual([
+      { uid: 'cs-1', _content_type_uid: 'author' },
+      { heroBlock: { uid: 'cs-2', _content_type_uid: 'category' } },
+    ]);
+  });
+
+  it('leaves asset field objects untouched (they need resolveAssetField, not a uid remap)', () => {
+    const value = { urlPath: '/assets/1', filename: 'f.jpg', uid: 'src-1' };
+    const out = resolveReferencesDeep('field', 'entry-1', value, locale, entryMapping);
+    expect(out).toBe(value);
+  });
+
+  it('passes scalars and unresolvable shapes through unchanged', () => {
+    expect(resolveReferencesDeep('field', 'entry-1', 'plain-string', locale, entryMapping)).toBe('plain-string');
+    expect(resolveReferencesDeep('field', 'entry-1', null, locale, entryMapping)).toBe(null);
+    expect(resolveReferencesDeep('field', 'entry-1', 42, locale, entryMapping)).toBe(42);
   });
 });
 

--- a/api/tests/unit/utils/entry-update.enrich.test.ts
+++ b/api/tests/unit/utils/entry-update.enrich.test.ts
@@ -120,3 +120,79 @@ describe('entry-update.utils — enrichConfigWithAssetMapping (extra branches)',
     expect(written.__assetMapping__).toEqual({ old: {}, new: {} });
   });
 });
+
+// Covers the fix for the "reference fields blank on localized entries" bug:
+// entry-update-script.cjs needs entry uid-mapper data (flat + per-locale)
+// threaded into the config under __entryMapping__, the same way asset uids
+// already are under __assetMapping__.
+describe('entry-update.utils — enrichConfigWithEntryMapping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writes empty old/new entry mappings when no uid-mapper files exist', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ page: {} }));
+
+    const { enrichConfigWithEntryMapping } = await import('../../../src/utils/entry-update.utils.js');
+    enrichConfigWithEntryMapping('/tmp/config.json', 'p1', 1, '/tmp/x.log');
+
+    const write = mockWriteFileSync.mock.calls.find((c) => c[0] === '/tmp/config.json');
+    const written = JSON.parse(String(write?.[1]));
+    expect(written.__entryMapping__).toEqual({
+      old: { flat: {}, byLocale: {} },
+      new: { flat: {}, byLocale: {} },
+    });
+  });
+
+  it('reads new-iteration entry + entryByLocale maps from uid-mapper.json', async () => {
+    mockExistsSync.mockImplementation((p: string) => p.includes('/2/uid-mapper.json'));
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p.includes('/2/uid-mapper.json')) {
+        return JSON.stringify({
+          entry: { 'src-a': 'cs-a' },
+          entryByLocale: { 'en-in': { 'src-a': 'cs-a-in' } },
+        });
+      }
+      return JSON.stringify({ page: {} }); // config file
+    });
+
+    const { enrichConfigWithEntryMapping } = await import('../../../src/utils/entry-update.utils.js');
+    enrichConfigWithEntryMapping('/tmp/config.json', 'p1', 2, '/tmp/x.log');
+
+    const write = mockWriteFileSync.mock.calls.find((c) => c[0] === '/tmp/config.json');
+    const written = JSON.parse(String(write?.[1]));
+    expect(written.__entryMapping__.new).toEqual({
+      flat: { 'src-a': 'cs-a' },
+      byLocale: { 'en-in': { 'src-a': 'cs-a-in' } },
+    });
+    expect(written.__entryMapping__.old).toEqual({ flat: {}, byLocale: {} });
+  });
+
+  it('reads both old (iteration-1) and new mappings when iteration > 1', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p.includes('/1/uid-mapper.json')) {
+        return JSON.stringify({ entry: { 'src-old': 'cs-old' }, entryByLocale: {} });
+      }
+      if (p.includes('/2/uid-mapper.json')) {
+        return JSON.stringify({ entry: { 'src-new': 'cs-new' }, entryByLocale: {} });
+      }
+      return JSON.stringify({ page: {} });
+    });
+
+    const { enrichConfigWithEntryMapping } = await import('../../../src/utils/entry-update.utils.js');
+    enrichConfigWithEntryMapping('/tmp/config.json', 'p1', 2, '/tmp/x.log');
+
+    const write = mockWriteFileSync.mock.calls.find((c) => c[0] === '/tmp/config.json');
+    const written = JSON.parse(String(write?.[1]));
+    expect(written.__entryMapping__.old.flat).toEqual({ 'src-old': 'cs-old' });
+    expect(written.__entryMapping__.new.flat).toEqual({ 'src-new': 'cs-new' });
+  });
+
+  it('swallows a read/parse error on the config file without throwing', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockReadFileSync.mockReturnValue('{ not json');
+
+    const { enrichConfigWithEntryMapping } = await import('../../../src/utils/entry-update.utils.js');
+    expect(() => enrichConfigWithEntryMapping('/tmp/config.json', 'p1', 1, '/tmp/x.log')).not.toThrow();
+  });
+});

--- a/api/tests/unit/utils/locale-migration.utils.test.ts
+++ b/api/tests/unit/utils/locale-migration.utils.test.ts
@@ -18,6 +18,7 @@ import {
   getMigratedLocales,
   isFullMigrationForLocale,
   recordMigratedLocales,
+  extractLocalesFromUpdateConfig,
 } from '../../../src/utils/locale-migration.utils';
 
 describe('locale-migration.utils', () => {
@@ -181,6 +182,62 @@ describe('locale-migration.utils', () => {
       mockProjectUpdate.mockImplementation(async (mut: any) => mut(data));
       await recordMigratedLocales('missing', ['en-us']);
       expect((data.projects[0] as any).migrated_locales).toBeUndefined();
+    });
+  });
+
+  // Covers the fix for the "locale marked migrated before it was ever
+  // actually processed" bug: runCli.service.ts used to compute the migrated
+  // locale set from the project's FULL configured locale list, which
+  // permanently skipped any locale configured ahead of when it was meant to
+  // be migrated. This helper extracts ONLY the locale(s) an iteration's delta
+  // pass actually queued, from updated-entries.json's compound
+  // `${csUid}::${localeCode}` keys.
+  describe('extractLocalesFromUpdateConfig', () => {
+    it('extracts locale codes from compound entry keys across content types', () => {
+      const config = {
+        article: { 'blt-1::en-in': {}, 'blt-2::en-in': {} },
+        author: { 'blt-3::en-in': {} },
+      };
+      expect(extractLocalesFromUpdateConfig(config)).toEqual(['en-in']);
+    });
+
+    it('dedupes locales seen across multiple entries', () => {
+      const config = {
+        article: { 'blt-1::en-gb': {}, 'blt-2::en-gb': {}, 'blt-3::en-in': {} },
+      };
+      const result = extractLocalesFromUpdateConfig(config);
+      expect(result).toEqual(expect.arrayContaining(['en-gb', 'en-in']));
+      expect(result).toHaveLength(2);
+    });
+
+    it('ignores bookkeeping keys (__assetMapping__, __entryMapping__, __assetUpdates__)', () => {
+      const config = {
+        __assetMapping__: { old: {}, new: {} },
+        __entryMapping__: { old: {}, new: {} },
+        __assetUpdates__: [{ uid: 'a' }],
+        article: { 'blt-1::en-gb': {} },
+      };
+      expect(extractLocalesFromUpdateConfig(config)).toEqual(['en-gb']);
+    });
+
+    it('ignores legacy keys with no locale suffix', () => {
+      const config = { page: { 'cs-1': { title: 'T' } } };
+      expect(extractLocalesFromUpdateConfig(config)).toEqual([]);
+    });
+
+    it('returns [] for null, undefined, or non-object input', () => {
+      expect(extractLocalesFromUpdateConfig(null)).toEqual([]);
+      expect(extractLocalesFromUpdateConfig(undefined)).toEqual([]);
+      expect(extractLocalesFromUpdateConfig('not an object' as any)).toEqual([]);
+    });
+
+    it('returns [] for an empty config object', () => {
+      expect(extractLocalesFromUpdateConfig({})).toEqual([]);
+    });
+
+    it('skips content types whose value is not an object', () => {
+      const config = { article: null, author: { 'blt-1::en-in': {} } };
+      expect(extractLocalesFromUpdateConfig(config)).toEqual(['en-in']);
     });
   });
 });

--- a/ui/src/components/ContentMapper/assetMapper.tsx
+++ b/ui/src/components/ContentMapper/assetMapper.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import {
   Button,
+  Icon,
   InfiniteScrollTable,
   Notification,
   EmptyState,
@@ -279,11 +280,12 @@ const AssetMapper = ({
   };
 
   const accessorAssetName = (data: AssetMapperType) => {
+    const name = data?.filename || data?.title || '-';
     return (
       <div>
         <div className='d-flex align-items-center'>
-          <div className={'cms-field cms-field--wrap'}>
-            {data?.filename || data?.title || '-'}
+          <div className={'cms-field cms-field--wrap'} title={name}>
+            {name}
           </div>
         </div>
       </div>
@@ -291,11 +293,12 @@ const AssetMapper = ({
   };
 
   const accessorAssetPath = (data: AssetMapperType) => {
+    const assetPath = data?.assetPath || '-';
     return (
       <div>
         <div className='d-flex align-items-center'>
-          <div className={'cms-field cms-field--wrap'}>
-            {data?.assetPath || '-'}
+          <div className={'cms-field cms-field--wrap'} title={assetPath}>
+            {assetPath}
           </div>
         </div>
       </div>
@@ -315,11 +318,12 @@ const AssetMapper = ({
   };
 
   const accessorContentstackUid = (data: AssetMapperType) => {
+    const uid = data?.contentstackAssetUid ? data?.contentstackAssetUid : '-';
     return (
       <div>
         <div className='d-flex align-items-center'>
-          <div className={'cms-field'}>
-            {data?.contentstackAssetUid ? data?.contentstackAssetUid : '-'}
+          <div className={'cms-field'} title={uid}>
+            {uid}
           </div>
         </div>
       </div>
@@ -334,7 +338,8 @@ const AssetMapper = ({
           className="asset-status-badge asset-status-badge--missing"
           title={data?.errorMessage || 'No source file found for this asset.'}
         >
-          No source
+          <Icon icon="InformationCircle" version="v2" size="tiny" />
+          <span>No source</span>
         </div>
       );
     }
@@ -345,13 +350,15 @@ const AssetMapper = ({
             className="asset-status-badge asset-status-badge--failed"
             title={data?.errorMessage || 'Failed to download this asset.'}
           >
-            Failed
+            <Icon icon="WarningBold" version="v2" size="tiny" />
+            <span>Failed</span>
           </span>
           <Button
             className="asset-retry-button"
             version="v2"
             buttonType="tertiary"
             size="small"
+            icon="Refresh"
             isLoading={!!retryingIds[sourceUid]}
             onClick={() => handleRetryAsset(data)}
           >
@@ -360,7 +367,12 @@ const AssetMapper = ({
         </div>
       );
     }
-    return null;
+    return (
+      <div className="asset-status-badge asset-status-badge--ok">
+        <Icon icon="CheckCircle" version="v2" size="tiny" />
+        <span>Ready</span>
+      </div>
+    );
   };
 
   const columns = [
@@ -373,14 +385,14 @@ const AssetMapper = ({
       ),
       accessor: accessorAssetName,
       id: 'uuid',
-      width: '400px',
+      width: '260px',
     },
     {
       disableSortBy: true,
       Header: (<span>{'Path:'}</span>),
       accessor: accessorAssetPath,
       id: '1',
-      width: '550px',
+      width: '480px',
     },
     {
       disableSortBy: true,
@@ -394,13 +406,14 @@ const AssetMapper = ({
       Header: (<span>{'Contentstack UIDs:'}</span>),
       accessor: accessorContentstackUid,
       id: '3',
+      width: '280px',
     },
     {
       disableSortBy: true,
       Header: (<span>{'Status:'}</span>),
       accessor: accessorAssetStatus,
       id: '4',
-      width: '160px',
+      width: '200px',
     }
   ];
 
@@ -424,21 +437,30 @@ const AssetMapper = ({
         /> :
         <div className="asset-mapper-table" ref={tableWrapperRef}>
           <div className="asset-mapper-toolbar">
-            {brokenAssetCount > 0 && (
+            {brokenAssetCount > 0 ? (
               <div className="asset-broken-banner">
-                {brokenAssetCount} asset{brokenAssetCount === 1 ? '' : 's'} will not be migrated due to a broken or missing source file.
+                <Icon icon="WarningBold" version="v2" size="small" />
+                <span>
+                  <strong>{brokenAssetCount}</strong>{' '}
+                  {`asset${brokenAssetCount === 1 ? '' : 's'} won't be migrated because the source file is broken or missing.`}
+                </span>
               </div>
+            ) : (
+              <span />
             )}
-            <Select
-              className="asset-status-select"
-              value={statusFilter}
-              options={statusFilterOptions}
-              onChange={(opt: { label: string; value: string }) => setStatusFilter(opt)}
-              isSearchable={false}
-              isClearable={false}
-              width="200px"
-              version="v2"
-            />
+            <div className="asset-status-filter">
+              <span className="asset-status-filter__label">Filter by status</span>
+              <Select
+                className="asset-status-select"
+                value={statusFilter}
+                options={statusFilterOptions}
+                onChange={(opt: { label: string; value: string }) => setStatusFilter(opt)}
+                isSearchable={false}
+                isClearable={false}
+                width="180px"
+                version="v2"
+              />
+            </div>
           </div>
           <InfiniteScrollTable
             key={'asset-mapper-table'}

--- a/ui/src/components/ContentMapper/assetMapper.tsx
+++ b/ui/src/components/ContentMapper/assetMapper.tsx
@@ -7,12 +7,14 @@ import {
   InfiniteScrollTable,
   Notification,
   EmptyState,
+  Select,
 } from '@contentstack/venus-components';
 
 // Services
 import {
   getAssetMapping,
   updateAssetMapper,
+  retryAssetDownload,
 } from '../../services/api/migration.service';
 
 // Redux
@@ -59,6 +61,8 @@ const AssetMapper = ({
   const [rowIds, setRowIds] = useState<Record<string, boolean>>({});
   const [persistedRowIds, setPersistedRowIds] = useState<Record<string, boolean>>({});
   const [isLoadingSaveButton, setisLoadingSaveButton] = useState<boolean>(false);
+  // Tracks in-flight retry calls per asset id so only that row's button shows a spinner.
+  const [retryingIds, setRetryingIds] = useState<Record<string, boolean>>({});
   // True once the initial fetch has settled — used to gate the empty state so it
   // doesn't flash before assets have loaded.
   const [hasFetched, setHasFetched] = useState<boolean>(false);
@@ -66,12 +70,35 @@ const AssetMapper = ({
   // table (and its search box) mounted even on 0 results, otherwise the user is
   // stranded on the full-page empty state with no way to clear the search.
   const [searchText, setSearchText] = useState<string>('');
+  // Status filter dropdown: 'all' | 'ok' | 'missing' | 'failed'.
+  const [statusFilter, setStatusFilter] = useState<{ label: string; value: string }>({
+    label: 'All statuses',
+    value: 'all',
+  });
+  // Aggregate counts across the FULL visible set (server-computed, unaffected by
+  // pagination/search/status-filter) — drives the "N assets won't be migrated" banner.
+  const [missingCount, setMissingCount] = useState<number>(0);
+  const [failedCount, setFailedCount] = useState<number>(0);
+
+  const statusFilterOptions = [
+    { label: 'All statuses', value: 'all' },
+    { label: 'Failed', value: 'failed' },
+    { label: 'No source', value: 'missing' },
+  ];
 
   const tableWrapperRef = useRef<HTMLDivElement | null>(null);
+  // Guards against a duplicate fetch when the mount-fetch and the
+  // status-filter-change-fetch would otherwise both fire on initial render.
+  const isFirstFetchRef = useRef(true);
 
+  // Fetch on mount, and refetch whenever the status filter changes (reset to page 1).
+  // Only the very first fetch seeds rowIds/persistedRowIds from the server.
   useEffect(() => {
-    fetchAssets('', { seedSelection: true });
-  }, []);
+    const seedSelection = isFirstFetchRef.current;
+    isFirstFetchRef.current = false;
+    fetchAssets(searchText, { seedSelection });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter?.value]);
 
   // Responsive table height for the asset mapper — see useMeasuredTableHeight for the why.
   const tableHeight = useMeasuredTableHeight(tableWrapperRef, [tableData?.length], {
@@ -93,7 +120,8 @@ const AssetMapper = ({
     try {
       setLoading(true);
 
-      const { data } = await getAssetMapping(skip, limit, searchVal ?? '', projectId);
+      const statusParam = statusFilter?.value && statusFilter.value !== 'all' ? statusFilter.value : undefined;
+      const { data } = await getAssetMapping(skip, limit, searchVal ?? '', projectId, statusParam);
 
       setLoading(false);
 
@@ -106,6 +134,10 @@ const AssetMapper = ({
       setTotalCounts(total);
       onCountChange?.(total);
       setHasFetched(true);
+      // Aggregate counts (missing/failed) are computed server-side across the full
+      // visible set, unaffected by pagination/search/status-filter — used for the banner.
+      setMissingCount(data?.missingCount ?? 0);
+      setFailedCount(data?.failedCount ?? 0);
 
       if (!seedSelection) {
         // Re-apply the user's current selection onto the freshly fetched page;
@@ -190,6 +222,62 @@ const AssetMapper = ({
     }
   };
 
+  /**
+   * Re-attempts the download for one asset that failed during the last migration run.
+   * Only re-stages the file locally — it lands in the destination stack on the next
+   * migration run, so success here just clears the "failed" status, it doesn't create
+   * the asset in Contentstack immediately.
+   */
+  const handleRetryAsset = async (asset: AssetMapperType) => {
+    const sourceUid = asset?.otherCmsAssetUid || asset?.id;
+    if (!sourceUid || retryingIds[sourceUid]) return;
+
+    setRetryingIds((prev) => ({ ...prev, [sourceUid]: true }));
+    try {
+      const { data } = await retryAssetDownload(projectId, sourceUid);
+      if (data?.success) {
+        setTableData((prev) =>
+          prev.map((row) =>
+            row.otherCmsAssetUid === sourceUid
+              ? { ...row, status: 'ok', errorMessage: undefined }
+              : row
+          )
+        );
+        Notification({
+          notificationContent: { text: data?.message || 'Asset downloaded successfully.' },
+          notificationProps: { position: 'bottom-center', hideProgressBar: true },
+          type: 'success',
+        });
+      } else {
+        setTableData((prev) =>
+          prev.map((row) =>
+            row.otherCmsAssetUid === sourceUid
+              ? { ...row, status: 'failed', errorMessage: data?.message }
+              : row
+          )
+        );
+        Notification({
+          notificationContent: { text: data?.message || 'Retry failed.' },
+          notificationProps: { position: 'bottom-center', hideProgressBar: true },
+          type: 'error',
+        });
+      }
+    } catch (error) {
+      console.error('handleRetryAsset -> error', error);
+      Notification({
+        notificationContent: { text: 'Retry failed.' },
+        notificationProps: { position: 'bottom-center', hideProgressBar: true },
+        type: 'error',
+      });
+    } finally {
+      setRetryingIds((prev) => {
+        const next = { ...prev };
+        delete next[sourceUid];
+        return next;
+      });
+    }
+  };
+
   const accessorAssetName = (data: AssetMapperType) => {
     return (
       <div>
@@ -238,6 +326,43 @@ const AssetMapper = ({
     );
   };
 
+  const accessorAssetStatus = (data: AssetMapperType) => {
+    const sourceUid = data?.otherCmsAssetUid || data?.id;
+    if (data?.status === 'missing') {
+      return (
+        <div
+          className="asset-status-badge asset-status-badge--missing"
+          title={data?.errorMessage || 'No source file found for this asset.'}
+        >
+          No source
+        </div>
+      );
+    }
+    if (data?.status === 'failed') {
+      return (
+        <div className="asset-status-badge asset-status-badge--failed-wrapper">
+          <span
+            className="asset-status-badge asset-status-badge--failed"
+            title={data?.errorMessage || 'Failed to download this asset.'}
+          >
+            Failed
+          </span>
+          <Button
+            className="asset-retry-button"
+            version="v2"
+            buttonType="tertiary"
+            size="small"
+            isLoading={!!retryingIds[sourceUid]}
+            onClick={() => handleRetryAsset(data)}
+          >
+            Retry
+          </Button>
+        </div>
+      );
+    }
+    return null;
+  };
+
   const columns = [
     {
       disableSortBy: true,
@@ -269,12 +394,21 @@ const AssetMapper = ({
       Header: (<span>{'Contentstack UIDs:'}</span>),
       accessor: accessorContentstackUid,
       id: '3',
+    },
+    {
+      disableSortBy: true,
+      Header: (<span>{'Status:'}</span>),
+      accessor: accessorAssetStatus,
+      id: '4',
+      width: '160px',
     }
   ];
 
+  const brokenAssetCount = missingCount + failedCount;
+
   return (
     <div className="step-container">
-      {(hasFetched && !loading && totalCounts === 0 && !searchText) ?
+      {(hasFetched && !loading && totalCounts === 0 && !searchText && statusFilter?.value === 'all') ?
         <EmptyState
           forPage="emptyStateV2"
           heading={<div className="empty_search_heading">{ASSET_MAPPER_EMPTY_STATE.NO_ASSETS_HEADING}</div>}
@@ -289,6 +423,23 @@ const AssetMapper = ({
           testId="no-results-found-page"
         /> :
         <div className="asset-mapper-table" ref={tableWrapperRef}>
+          <div className="asset-mapper-toolbar">
+            {brokenAssetCount > 0 && (
+              <div className="asset-broken-banner">
+                {brokenAssetCount} asset{brokenAssetCount === 1 ? '' : 's'} will not be migrated due to a broken or missing source file.
+              </div>
+            )}
+            <Select
+              className="asset-status-select"
+              value={statusFilter}
+              options={statusFilterOptions}
+              onChange={(opt: { label: string; value: string }) => setStatusFilter(opt)}
+              isSearchable={false}
+              isClearable={false}
+              width="200px"
+              version="v2"
+            />
+          </div>
           <InfiniteScrollTable
             key={'asset-mapper-table'}
             loading={loading}

--- a/ui/src/components/ContentMapper/contentMapper.interface.ts
+++ b/ui/src/components/ContentMapper/contentMapper.interface.ts
@@ -250,4 +250,10 @@ export interface AssetMapperType {
   isChanged?: boolean;
   contentstackAssetUid?: string;
   _canSelect?: boolean;
+  hasSource?: boolean;
+  // 'missing' — no url/upload in the source at all, nothing to retry.
+  // 'failed' — had a source but the last migration run's download attempt threw; retriable.
+  // 'ok' — no known issue.
+  status?: 'missing' | 'failed' | 'ok';
+  errorMessage?: string;
 }

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -116,6 +116,14 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
   // user's configured mapping regardless of redux hydration timing on restart.
   const [localeOptions, setLocaleOptions] = useState<{ label: string; value: string }[]>([]);
   const [selectedLocale, setSelectedLocale] = useState<{ label: string; value: string } | null>(null);
+  // True once the locale-fetch effect below has settled (success or failure). Used as a
+  // safety net: if getProject fails, or the project has no master_locale/locales at all,
+  // selectedLocale stays null forever and the entries-fetch effect (keyed on
+  // contentTypeUid && selectedLocale) would never fire — leaving Map Entry on an empty
+  // table with no spinner and no error. Once resolution has settled with no options, fall
+  // back to the unfiltered fetch (server-side getEntryMapping already falls open when no
+  // locale is provided).
+  const [localesResolved, setLocalesResolved] = useState(false);
 
   /** ALL HOOKS HERE */
   const { projectId = '' } = useParams<{ projectId: string }>();
@@ -180,6 +188,8 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
         if (opts?.length > 0) setSelectedLocale(opts[0]);
       } catch (err) {
         console.error('Failed to load project locales', err);
+      } finally {
+        setLocalesResolved(true);
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -196,6 +206,16 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedLocale?.value, contentTypeUid]);
+
+  // Safety net: locale resolution settled (getProject failed, or the project has no
+  // master_locale/locales at all) with nothing selected — fall back to the unfiltered
+  // fetch instead of leaving the table empty forever with no spinner and no error.
+  useEffect(() => {
+    if (contentTypeUid && localesResolved && !selectedLocale?.value) {
+      fetchEntries(contentTypeUid, searchText || '', { seedSelection: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contentTypeUid, localesResolved]);
 
   /********** HELPERS *************/
   /********** CONTENT TYPE LIST (left panel) *************/
@@ -271,11 +291,10 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
     setActive(i);
     const ct = filteredContentTypes?.[i];
     setOtherCmsTitle(ct?.otherCmsTitle ?? '');
-    setContentTypeUid(ct?.id ?? '');
     setOtherCmsUid(ct?.otherCmsUid ?? '');
-    if (ct?.id) {
-      fetchEntries(ct.id, searchText || '', { seedSelection: true });
-    }
+    // setContentTypeUid alone re-triggers the [contentTypeUid, selectedLocale] data-load
+    // effect above — calling fetchEntries directly here too would double the request.
+    setContentTypeUid(ct?.id ?? '');
   };
 
   const handleSchemaPreview = async (title: string, ctId: string) => {
@@ -331,11 +350,9 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
       const first = nextList[0];
       setActive(0);
       setOtherCmsTitle(first?.otherCmsTitle ?? '');
-      setContentTypeUid(first?.id ?? '');
       setOtherCmsUid(first?.otherCmsUid ?? '');
-      if (first?.id) {
-        fetchEntries(first.id, searchText || '', { seedSelection: true });
-      }
+      // setContentTypeUid alone re-triggers the data-load effect — see handleOpenContentType.
+      setContentTypeUid(first?.id ?? '');
     }
     setShowFilter(false);
   };

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -52,7 +52,6 @@ import {
   mapEntriesToRows,
   buildSelectedEntryRowIds,
   applySelectionToEntries,
-  selectableInitialRows,
   filterContentTypesByStatus,
   applyContentTypeStatus,
 } from './entryMapper.utils';
@@ -110,7 +109,6 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
   const [rowIds, setRowIds] = useState<Record<string, boolean>>({});
   const [persistedRowIds, setPersistedRowIds] = useState<Record<string, boolean>>({});
   const [isLoadingSaveButton, setisLoadingSaveButton] = useState<boolean>(false);
-  const [initialRowSelectedData, setInitialRowSelectedData] = useState<EntryMapperType[]>([]);
 
   // Locale dropdown — sourced from project.json (master_locale + locales) so it reflects the
   // user's configured mapping regardless of redux hydration timing on restart.
@@ -252,7 +250,6 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
     setTotalCounts(0);
     setRowIds({});
     setPersistedRowIds({});
-    setInitialRowSelectedData([]);
     setOtherCmsTitle('');
     setContentTypeUid('');
     setOtherCmsUid('');
@@ -395,7 +392,6 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
       const total = data?.count ?? validTableData?.length ?? 0;
 
       setTotalCounts(total);
-      setInitialRowSelectedData(selectableInitialRows(validTableData));
 
       if (!seedSelection) {
         // Re-apply the user's current selection onto the freshly fetched page;

--- a/ui/src/components/ContentMapper/entryMapper.tsx
+++ b/ui/src/components/ContentMapper/entryMapper.tsx
@@ -122,6 +122,15 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
   const navigate = useNavigate();
   const filterRef = useRef<HTMLDivElement | null>(null);
   const tableWrapperRef = useRef<HTMLDivElement | null>(null);
+  // Monotonic id per fetchEntries call. Any response whose id no longer matches the
+  // latest issued call is ignored — prevents a stale in-flight fetch from a previous
+  // locale/content-type from clobbering the current view's rowIds / persistedRowIds
+  // when responses land out of order.
+  const fetchGenerationRef = useRef(0);
+  // Bumped after every successful seedSelection fetch. Used as part of the Table's
+  // `key` so the Table remounts with FRESH rowIds already committed — remounting on
+  // locale change alone was too early (rowIds was still the previous locale's).
+  const [tableRevision, setTableRevision] = useState(0);
 
   /********** ALL USEEFFECT HERE *************/
   useEffect(() => {
@@ -176,13 +185,17 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId, selectedOrganisation?.uid]);
 
-  // Refetch the entry list when the user switches locale so isUpdate reflects the per-locale flag.
+  // Fetch the entry list once both contentTypeUid AND selectedLocale are ready, and refetch
+  // whenever either changes. Depending on both handles the initial-mount race where content
+  // types load before/after the locale mapping — whichever resolves last triggers the fetch,
+  // so we never call the API without a locale filter (which would return mixed-locale rows
+  // and clobber the Venus Table's initial selection snapshot).
   useEffect(() => {
     if (contentTypeUid && selectedLocale?.value) {
       fetchEntries(contentTypeUid, searchText || '', { seedSelection: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedLocale?.value]);
+  }, [selectedLocale?.value, contentTypeUid]);
 
   /********** HELPERS *************/
   /********** CONTENT TYPE LIST (left panel) *************/
@@ -200,9 +213,11 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
       setOtherCmsTitle(data?.contentTypes?.[0]?.otherCmsTitle ?? '');
       setContentTypeUid(data?.contentTypes?.[0]?.id ?? '');
       setOtherCmsUid(data?.contentTypes?.[0]?.otherCmsUid ?? '');
-      if (data?.contentTypes?.[0]?.id) {
-        fetchEntries(data?.contentTypes?.[0]?.id, searchVal ?? '', { seedSelection: true });
-      }
+      // Don't fetch entries here — the locale-effect at [selectedLocale.value] will fire
+      // once both contentTypeUid and selectedLocale are ready. Fetching now would run
+      // without a locale filter (selectedLocale is still null on initial mount), so the
+      // server would return all-locale rows and Venus's Table would snapshot that mixed
+      // selection state before the correct per-locale fetch could overwrite it.
     } catch (error) {
       setIsLoading(false);
       console.error(error);
@@ -345,10 +360,17 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
     searchVal: string,
     { skip = 0, limit = 30, seedSelection = false }: { skip?: number; limit?: number; seedSelection?: boolean } = {},
   ) => {
+    const gen = ++fetchGenerationRef.current;
     try {
       setLoading(true);
 
       const { data } = await getEntryMapping(ctId || '', skip, limit, searchVal, projectId, selectedLocale?.value);
+
+      // Ignore this response entirely if the user has since triggered another fetch —
+      // e.g. quickly switched locales or content types. Without this, an earlier fetch
+      // finishing after a later one would overwrite rowIds/persistedRowIds with data
+      // for the wrong locale, silently deselecting entries the user just saved.
+      if (gen !== fetchGenerationRef.current) return;
 
       setLoading(false);
 
@@ -369,9 +391,15 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
       setTableData(validTableData ?? []);
       setRowIds(initialSelected);
       setPersistedRowIds(initialSelected);
+      // Force the Table to remount so it re-reads initialSelectedRowIds with the
+      // just-committed rowIds. Venus's InfiniteScrollTable snapshots that prop at
+      // mount and ignores subsequent updates; without a remount, switching locales
+      // shows the previous locale's checkboxes on the new data.
+      setTableRevision((r) => r + 1);
       // Reflect any pre-existing entry selections on the content type icon (green when present).
       updateContentTypeStatus(ctId, Object.keys(initialSelected ?? {}).length > 0);
     } catch (error) {
+      if (gen !== fetchGenerationRef.current) return;
       console.error('fetchEntries -> error', error);
       setLoading(false);
     }
@@ -642,7 +670,12 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
                 )}
                 <div className="entry-mapper-table">
                   <InfiniteScrollTable
-                  key={contentTypeUid || 'entry-mapper-table'}
+                  // `tableRevision` bumps AFTER a seedSelection fetch commits rowIds — so
+                  // the Table remounts with the correct initial selection already in state.
+                  // Keying on selectedLocale alone would remount too early (rowIds still
+                  // holding the previous locale's data, since the new fetch is still
+                  // in flight).
+                  key={`${contentTypeUid || 'entry-mapper-table'}::${tableRevision}`}
                   loading={loading}
                   canSearch={true}
                   totalCounts={totalCounts ?? 0}
@@ -658,7 +691,6 @@ const EntryMapper = ({ handleStepChange }: entryMapperProps) => {
                   v2Features={{ pagination: true, isNewEmptyState: true }}
                   rowPerPageOptions={[10, 30, 50, 100]}
                   minBatchSizeToFetch={30}
-                  initialRowSelectedData={initialRowSelectedData}
                   initialSelectedRowIds={rowIds}
                   itemSize={70}
                   getSelectedRow={handleSelectedEntries}

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -905,3 +905,61 @@ div .table-row {
     position: static;
   }
 }
+
+// Asset status column badges (Map Entry Assets tab): 'missing' (no source at all, nothing
+// to retry) vs 'failed' (had a source, last migration run's download attempt threw —
+// shown with a Retry button).
+.asset-status-badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+
+  &--missing {
+    background-color: #f1f1f1;
+    color: #647696;
+    cursor: help;
+  }
+
+  &--failed {
+    background-color: #fdecea;
+    color: #c0392b;
+    cursor: help;
+  }
+
+  &--failed-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: none;
+    padding: 0;
+  }
+}
+
+.asset-retry-button {
+  padding: 0 8px !important;
+}
+
+// Toolbar above the asset table: broken-asset count banner (left) + status filter (right).
+.asset-mapper-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  flex: 0 0 auto;
+}
+
+.asset-broken-banner {
+  font-size: 0.8125rem;
+  color: #c0392b;
+  background-color: #fdecea;
+  padding: 4px 10px;
+  border-radius: 4px;
+}
+
+.asset-status-select {
+  margin-left: auto;
+}

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -64,6 +64,21 @@
 .asset-mapper-table .Table__body__column {
   min-width: 0 !important;
 }
+// Belt-and-braces: clip anything that still doesn't shrink to its column's share
+// instead of visually bleeding into the next column.
+.asset-mapper-table .Table__body__column {
+  overflow: hidden;
+}
+// The header row sizes itself to its (single-line) content rather than a fixed height,
+// but the body below it starts at a fixed offset computed for that single line. A header
+// label too long for its column wraps to a 2nd line that the fixed offset doesn't account
+// for, so it spills down and gets covered by row 1. Force header labels to a single,
+// ellipsized line instead of wrapping.
+.asset-mapper-table .Table__head__column {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
 .table-wrapper .Table__body__column .d-flex,
 .asset-mapper-table .Table__body__column .d-flex {
   min-width: 0;
@@ -78,13 +93,21 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+// Venus's Table row is a fixed 60px (.Table__body__row { height: 60px }) — it does not
+// grow with content, and that's too tight to reliably fit 2 wrapped lines (2 × the
+// column's 1.5rem line-height already exceeds the ~44px available after padding), which
+// bled the cell into the row below/the header above. Truncate to a single line with an
+// ellipsis instead — same pattern as the non-wrap `.cms-field` columns — and rely on the
+// native `title` attribute for the full value on hover.
 .asset-mapper-table .cms-field--wrap {
-  display: block;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
   width: 100%;
   max-width: 100%;
   min-width: 0;
-  -webkit-line-clamp: unset;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: normal;
   overflow-wrap: anywhere;
   word-break: break-all;
@@ -906,26 +929,43 @@ div .table-row {
   }
 }
 
-// Asset status column badges (Map Entry Assets tab): 'missing' (no source at all, nothing
-// to retry) vs 'failed' (had a source, last migration run's download attempt threw —
-// shown with a Retry button).
+// Asset status column badges (Map Entry Assets tab): 'ok' (ready to migrate), 'missing'
+// (no source at all, nothing to retry) vs 'failed' (had a source, last migration run's
+// download attempt threw — shown with a Retry button).
 .asset-status-badge {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   font-size: 0.75rem;
   font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 4px;
+  line-height: 1;
+  padding: 4px 10px;
+  border-radius: 999px;
   white-space: nowrap;
+  border: 1px solid transparent;
+
+  svg,
+  img {
+    flex: 0 0 auto;
+  }
+
+  &--ok {
+    background-color: #e8f6ee;
+    color: #1a8245;
+    border-color: rgba(26, 130, 69, 0.2);
+  }
 
   &--missing {
-    background-color: #f1f1f1;
+    background-color: #f1f2f5;
     color: #647696;
+    border-color: rgba(100, 118, 150, 0.2);
     cursor: help;
   }
 
   &--failed {
     background-color: #fdecea;
     color: #c0392b;
+    border-color: rgba(192, 57, 43, 0.2);
     cursor: help;
   }
 
@@ -935,11 +975,13 @@ div .table-row {
     gap: 8px;
     background: none;
     padding: 0;
+    border: none;
   }
 }
 
 .asset-retry-button {
-  padding: 0 8px !important;
+  padding: 0 10px !important;
+  font-weight: 600 !important;
 }
 
 // Toolbar above the asset table: broken-asset count banner (left) + status filter (right).
@@ -947,19 +989,46 @@ div .table-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 8px 16px;
+  gap: 16px;
+  padding: 10px 16px;
   flex: 0 0 auto;
+  border-bottom: 1px solid #e6e9ef;
+  background-color: #fbfbfc;
 }
 
 .asset-broken-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 0.8125rem;
-  color: #c0392b;
-  background-color: #fdecea;
-  padding: 4px 10px;
-  border-radius: 4px;
+  color: #92400e;
+  background-color: #fef3e2;
+  border: 1px solid rgba(146, 64, 14, 0.2);
+  padding: 6px 12px;
+  border-radius: 6px;
+  line-height: 1.35;
+
+  svg,
+  img {
+    flex: 0 0 auto;
+    color: #b45309;
+  }
+
+  strong {
+    font-weight: 700;
+  }
 }
 
-.asset-status-select {
+.asset-status-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-left: auto;
+  flex: 0 0 auto;
+
+  &__label {
+    font-size: 0.8125rem;
+    color: #647696;
+    white-space: nowrap;
+  }
 }

--- a/ui/src/components/ContentMapper/index.scss
+++ b/ui/src/components/ContentMapper/index.scss
@@ -523,6 +523,31 @@ div .table-row {
   padding-bottom: 6rem;
 }
 
+// Asset mapper search-empty state — mirror the entry-mapper-container pattern:
+// give the .Table explicit height when it contains an .EmptyState (Venus's measured
+// tableHeight collapses to ~56px on empty results, so the centered empty state has
+// no room to display). Then make .Table__body a flex column and center the
+// .Table__centerWrapper Venus renders around the customEmptyState.
+.asset-mapper-table .Table:has(.EmptyState) {
+  height: calc(100vh - 22rem) !important;
+}
+
+.asset-mapper-table .Table:has(.Table__centerWrapper) .Table__body {
+  display: flex;
+  flex-direction: column;
+}
+
+.asset-mapper-table .Table__centerWrapper {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 300px;
+  padding-bottom: 2rem;
+}
+
 // Field mapping table (Map Content Fields step): center the search-empty state. Anchor on
 // the venus .Table and take .Table__centerWrapper out of flow (position: absolute) so it
 // overlays the full table area and centers, instead of stacking under the header rows.

--- a/ui/src/components/LogScreen/MigrationLogViewer.tsx
+++ b/ui/src/components/LogScreen/MigrationLogViewer.tsx
@@ -194,11 +194,12 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
       logsContainerRef.current.scrollTop = logsContainerRef.current.scrollHeight;
     }
 
-    // Only inspect the tail — completion is always the terminal message. Scanning the whole
-    // array made a replayed / rehydrated "Migration Process Completed" mid-array flip the UI
-    // back to the completion view on iter 2. Also gate on migrationStarted so a rehydrated
-    // log array from a previous run doesn't trigger completion on mount.
-    const lastLog = logs?.[logs.length - 1];
+    // Look for a terminal message anywhere in `logs`. Scanning the whole array is safe here
+    // because the effect above purges `logs` back to the placeholder when migrationStarted
+    // flips false→true — anything present is from the current run, not a replay.
+    // We can't inspect only the last entry: after the CLI emits "Migration Process Completed"
+    // the backend still writes uid-mapper / "No config file generated" lines, burying the
+    // terminal message mid-array on the delta path.
     const migrationStarted = newMigrationData?.migration_execution?.migrationStarted;
     // Full/master import ends with "Migration Process Completed"; the delta update path ends
     // with "Entry Update Process Completed" — accept either as the terminal message.
@@ -206,11 +207,14 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
       'Migration Process Completed',
       'Entry Update Process Completed'
     ]);
-    if (migrationStarted && lastLog) {
+    const hasTerminalMessage = logs?.some(
+      (log) => log?.message && TERMINAL_MESSAGES.has(log.message)
+    );
+    if (migrationStarted && hasTerminalMessage) {
       try {
-        const message = lastLog.message;
+        const message = 'Migration Process Completed';
 
-        if (message && TERMINAL_MESSAGES.has(message) && !hasShownCompletionNotification) {
+        if (!hasShownCompletionNotification) {
           setIsModalOpen(true);
           setHasShownCompletionNotification(true);
 

--- a/ui/src/components/LogScreen/MigrationLogViewer.tsx
+++ b/ui/src/components/LogScreen/MigrationLogViewer.tsx
@@ -124,10 +124,14 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
     }
   }, [newMigrationData?.migration_execution?.migrationCompleted, dispatch]);
 
-  // Reset notification flag when a new migration starts
+  // Reset notification flag AND purge stale logs when a new migration starts. Without the log
+  // purge, a replayed "Migration Process Completed" line from the previous run (on socket
+  // reconnect / late buffered emit) would slip through the completion detector below and flip
+  // the UI straight back to the iter-1 completion view.
   useEffect(() => {
     if (newMigrationData?.migration_execution?.migrationStarted && !newMigrationData?.migration_execution?.migrationCompleted) {
       setHasShownCompletionNotification(false);
+      setLogs([{ message: 'Migration logs will appear here once the process begins.', level: '' }]);
     }
   }, [newMigrationData?.migration_execution?.migrationStarted, newMigrationData?.migration_execution?.migrationCompleted]);
 
@@ -190,12 +194,23 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
       logsContainerRef.current.scrollTop = logsContainerRef.current.scrollHeight;
     }
 
-    logs?.forEach((log) => {
+    // Only inspect the tail — completion is always the terminal message. Scanning the whole
+    // array made a replayed / rehydrated "Migration Process Completed" mid-array flip the UI
+    // back to the completion view on iter 2. Also gate on migrationStarted so a rehydrated
+    // log array from a previous run doesn't trigger completion on mount.
+    const lastLog = logs?.[logs.length - 1];
+    const migrationStarted = newMigrationData?.migration_execution?.migrationStarted;
+    // Full/master import ends with "Migration Process Completed"; the delta update path ends
+    // with "Entry Update Process Completed" — accept either as the terminal message.
+    const TERMINAL_MESSAGES = new Set([
+      'Migration Process Completed',
+      'Entry Update Process Completed'
+    ]);
+    if (migrationStarted && lastLog) {
       try {
-        //const logObject = JSON.parse(log);
-        const message = log.message;
+        const message = lastLog.message;
 
-        if (message === 'Migration Process Completed' && !hasShownCompletionNotification) {
+        if (message && TERMINAL_MESSAGES.has(message) && !hasShownCompletionNotification) {
           setIsModalOpen(true);
           setHasShownCompletionNotification(true);
 
@@ -228,8 +243,8 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
       } catch (error) {
         console.error('Invalid JSON string', error);
       }
-    });
-  }, [logs]);
+    }
+  }, [logs, newMigrationData?.migration_execution?.migrationStarted]);
 
   const navigate = useNavigate();
 
@@ -276,56 +291,57 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
               transition: 'transform 0.1s ease'
             }}
           >
-            {logs.map((log, index) => {
-              try {
-                //const logObject = JSON.parse(log);
-                const { level, timestamp, message } = log;
-
-                return newMigrationData?.destination_stack?.migratedStacks?.includes(
-                  newMigrationData?.destination_stack?.selectedStack?.value
-                ) ? (
-                  <div
-                    key={`${index?.toString}`}
-                    style={logStyles[level || ''] || logStyles.info}
-                    className="log-entry text-center"
-                  >
+            {(() => {
+              // Only show the "already migrated" placeholder when the user has NOT started
+              // a new run on this screen — otherwise iter 2 (which legitimately targets the
+              // same stack) would sit behind this message. Rendering it outside the .map
+              // also fixes the previous bug where the message repeated once per log line.
+              const stackAlreadyMigrated = newMigrationData?.destination_stack?.migratedStacks?.includes(
+                newMigrationData?.destination_stack?.selectedStack?.value
+              );
+              const migrationStarted = newMigrationData?.migration_execution?.migrationStarted;
+              if (stackAlreadyMigrated && !migrationStarted) {
+                return (
+                  <div style={logStyles.info} className="log-entry text-center">
                     <div className="log-message generic-log-message">
                       Migration has already done in selected stack. Please create a new project.
                     </div>
                   </div>
-                ) : (
-                  <div
-                    key={index}
-                    // style={logStyles[level || ''] || logStyles.info}
-                    // className="log-entry logs-bg"
-                  >
-                    {message === 'Migration logs will appear here once the process begins.' ? (
-                      <div
-                        style={logStyles[level || ''] || logStyles.info}
-                        className="log-entry text-center"
-                      >
-                        <div className="log-message generic-log-message">{message}</div>
-                      </div>
-                    ) : (
-                      <div
-                        style={logStyles[level || ''] || logStyles.info}
-                        className="log-entry"
-                      >
-                        <div className="log-time">
-                          {timestamp
-                            ? new Date(timestamp)?.toTimeString()?.split(' ')[0]
-                            : new Date()?.toTimeString()?.split(' ')[0]}
-                        </div>
-                        <div className="log-message">{message}</div>
-                      </div>
-                    )}
-                  </div>
                 );
-              } catch (error) {
-                console.error('Invalid log format', error);
-                return null;
               }
-            })}
+              return logs.map((log, index) => {
+                try {
+                  const { level, timestamp, message } = log;
+                  return (
+                    <div key={index}>
+                      {message === 'Migration logs will appear here once the process begins.' ? (
+                        <div
+                          style={logStyles[level || ''] || logStyles.info}
+                          className="log-entry text-center"
+                        >
+                          <div className="log-message generic-log-message">{message}</div>
+                        </div>
+                      ) : (
+                        <div
+                          style={logStyles[level || ''] || logStyles.info}
+                          className="log-entry"
+                        >
+                          <div className="log-time">
+                            {timestamp
+                              ? new Date(timestamp)?.toTimeString()?.split(' ')[0]
+                              : new Date()?.toTimeString()?.split(' ')[0]}
+                          </div>
+                          <div className="log-message">{message}</div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                } catch (error) {
+                  console.error('Invalid log format', error);
+                  return null;
+                }
+              });
+            })()}
           </div>
         )}
       </div>

--- a/ui/src/components/LogScreen/MigrationLogViewer.tsx
+++ b/ui/src/components/LogScreen/MigrationLogViewer.tsx
@@ -124,10 +124,12 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
     }
   }, [newMigrationData?.migration_execution?.migrationCompleted, dispatch]);
 
-  // Reset notification flag AND purge stale logs when a new migration starts. Without the log
-  // purge, a replayed "Migration Process Completed" line from the previous run (on socket
-  // reconnect / late buffered emit) would slip through the completion detector below and flip
-  // the UI straight back to the iter-1 completion view.
+  // Reset notification flag AND purge stale logs when a new migration starts. The server
+  // streams from a monotonic file offset (server.ts) so a normal socket reconnect never
+  // replays old lines — but an API restart resets that offset to 0 and re-emits the whole
+  // log file to every client. Without this purge, a prior run's terminal message surviving
+  // in `logs` after an API restart would slip through the completion detector below and
+  // flip the UI straight back to the previous run's completion view.
   useEffect(() => {
     if (newMigrationData?.migration_execution?.migrationStarted && !newMigrationData?.migration_execution?.migrationCompleted) {
       setHasShownCompletionNotification(false);
@@ -201,14 +203,18 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
     // the backend still writes uid-mapper / "No config file generated" lines, burying the
     // terminal message mid-array on the delta path.
     const migrationStarted = newMigrationData?.migration_execution?.migrationStarted;
-    // Full/master import ends with "Migration Process Completed"; the delta update path ends
-    // with "Entry Update Process Completed" — accept either as the terminal message.
-    const TERMINAL_MESSAGES = new Set([
-      'Migration Process Completed',
-      'Entry Update Process Completed'
-    ]);
+    // On iteration 1 there's only a bulk import — "Migration Process Completed" IS terminal.
+    // On iteration 2+ (delta) that message only marks the bulk-import phase; the run isn't
+    // actually done until the update/localize CLI finishes and writes
+    // "Entry Update Process Completed" afterward. Treating either as terminal on a delta run
+    // would fire the completion modal early, hiding the still-streaming localize pass (and any
+    // "Failed to update entries" error in it) behind the completion view.
+    const isDeltaIteration = (newMigrationData?.iteration ?? 1) > 1;
+    const requiredTerminalMessage = isDeltaIteration
+      ? 'Entry Update Process Completed'
+      : 'Migration Process Completed';
     const hasTerminalMessage = logs?.some(
-      (log) => log?.message && TERMINAL_MESSAGES.has(log.message)
+      (log) => log?.message === requiredTerminalMessage
     );
     if (migrationStarted && hasTerminalMessage) {
       try {
@@ -248,7 +254,7 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
         console.error('Invalid JSON string', error);
       }
     }
-  }, [logs, newMigrationData?.migration_execution?.migrationStarted]);
+  }, [logs, newMigrationData?.migration_execution?.migrationStarted, newMigrationData?.iteration]);
 
   const navigate = useNavigate();
 

--- a/ui/src/components/MigrationFlowHeader/index.scss
+++ b/ui/src/components/MigrationFlowHeader/index.scss
@@ -7,6 +7,12 @@
   position: fixed;
   width: calc(100% - 56px);
   z-index: 9;
+  // Duplicate the .d-flex / .justify-content-between / .align-items-center
+  // behavior locally so the header stays title-left / button-right even when
+  // Bootstrap utilities from the external CDN fail to load.
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   .back-btn {
     padding: 0;
   }

--- a/ui/src/pages/Migration/index.tsx
+++ b/ui/src/pages/Migration/index.tsx
@@ -907,11 +907,15 @@ const Migration = () => {
         );
 
         if (migrationRes?.status === 200) {
+          // Explicitly clear migrationCompleted here — otherwise a stale flag carried over
+          // from iter 1 (via fetchProjectData rehydration) leaves the completion view rendered
+          // on iter 2 until the next state change.
           const newMigrationDataObj: INewMigration = {
             ...newMigrationData,
             migration_execution: {
               ...newMigrationData?.migration_execution,
-              migrationStarted: true
+              migrationStarted: true,
+              migrationCompleted: false
             }
           };
           dispatch(updateNewMigrationData(newMigrationDataObj));

--- a/ui/src/services/api/migration.service.ts
+++ b/ui/src/services/api/migration.service.ts
@@ -428,12 +428,14 @@ export const getAssetMapping = async (
   skip: number,
   limit: number,
   searchText: string,
-  projectId: string
+  projectId: string,
+  status?: string
 ) => {
   try {
     const encodedSearchText = encodeURIComponent(searchText);
+    const statusQuery = status ? `&status=${encodeURIComponent(status)}` : '';
     return await getCall(
-      `${API_VERSION}/mapper/assetMapping/${projectId}/${skip}/${limit}/${encodedSearchText}?`,
+      `${API_VERSION}/mapper/assetMapping/${projectId}/${skip}/${limit}/${encodedSearchText}?${statusQuery}`,
       options()
     );
   } catch (error) {
@@ -453,6 +455,25 @@ export const updateAssetMapper = async (
     return await putCall(
       `${API_VERSION}/mapper/updateAssetStatus/${projectId}`,
       data,
+      options()
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`${error.message}`);
+    } else {
+      throw new Error('Unknown error');
+    }
+  }
+};
+
+export const retryAssetDownload = async (
+  projectId: string,
+  assetUid: string
+) => {
+  try {
+    return await putCall(
+      `${API_VERSION}/mapper/retryAsset/${projectId}/${assetUid}`,
+      {},
       options()
     );
   } catch (error) {

--- a/upload-api/migration-contentful/libs/extractAssets.js
+++ b/upload-api/migration-contentful/libs/extractAssets.js
@@ -33,7 +33,7 @@ const { readFile } = require('../utils/helper');
  * matching the AEM/Sitecore AssetMappingRow shape.
  *
  * @param {string} cleanLocalPath - Path to the Contentful export JSON file.
- * @returns {Array<{id:string,otherCmsAssetUid:string,filename:string,title:string,file_size:(number|string),assetPath:string,isUpdate:boolean}>}
+ * @returns {Array<{id:string,otherCmsAssetUid:string,filename:string,title:string,file_size:(number|string),assetPath:string,isUpdate:boolean,hasSource:boolean}>}
  */
 const extractAssets = (cleanLocalPath) => {
   try {
@@ -82,13 +82,6 @@ const extractAssets = (cleanLocalPath) => {
         assetPath = file.upload;
       }
 
-      // Skip assets that have no downloadable source at all — they'd only confuse
-      // the user on Map Entry (nothing to select for something the migration
-      // can't upload anyway).
-      if (!assetPath) {
-        continue;
-      }
-
       const filename =
         (typeof file?.fileName === 'string' && file?.fileName) || title || '';
       const fileSize = file?.details?.size ?? '';
@@ -103,6 +96,11 @@ const extractAssets = (cleanLocalPath) => {
         file_size: fileSize,
         assetPath,
         isUpdate: false,
+        // No `.url` and no `.upload` at all — nothing the migration can ever download for
+        // this asset. Still emit the row (rather than silently dropping it) so the user sees
+        // *why* it's missing instead of the asset count on Map Entry mysteriously not
+        // matching the source export. `hasSource: false` rows are always non-selectable.
+        hasSource: Boolean(assetPath),
       });
     }
 

--- a/upload-api/migration-contentful/libs/extractAssets.js
+++ b/upload-api/migration-contentful/libs/extractAssets.js
@@ -71,15 +71,27 @@ const extractAssets = (cleanLocalPath) => {
       const titleValue = pickLocalized(asset?.fields?.title);
       const title = typeof titleValue === 'string' ? titleValue : '';
 
+      // Contentful serves processed assets from a protocol-relative CDN URL ("//...")
+      // in `.url`. Freshly-added, not-yet-processed assets only have `.upload`, an
+      // absolute fetch URL. Prefer `.url` (with https normalization) and fall back
+      // to `.upload` so newly-added assets aren't dropped from Map Entry.
+      let assetPath = '';
+      if (typeof file?.url === 'string' && file.url) {
+        assetPath = file.url.startsWith('//') ? `https:${file.url}` : file.url;
+      } else if (typeof file?.upload === 'string' && file.upload) {
+        assetPath = file.upload;
+      }
+
+      // Skip assets that have no downloadable source at all — they'd only confuse
+      // the user on Map Entry (nothing to select for something the migration
+      // can't upload anyway).
+      if (!assetPath) {
+        continue;
+      }
+
       const filename =
         (typeof file?.fileName === 'string' && file?.fileName) || title || '';
       const fileSize = file?.details?.size ?? '';
-      // Contentful serves assets from a protocol-relative CDN URL ("//...");
-      // normalize to https so downstream consumers get an absolute URL.
-      let assetPath = typeof file?.url === 'string' ? file?.url : '';
-      if (assetPath.startsWith('//')) {
-        assetPath = `https:${assetPath}`;
-      }
 
       seenIds.add(id);
 

--- a/upload-api/migration-contentful/libs/extractEntries.js
+++ b/upload-api/migration-contentful/libs/extractEntries.js
@@ -9,6 +9,33 @@ const { readFile } = require('../utils/helper');
  * @param {string} cleanLocalPath - Path to the Contentful export JSON file.
  * @returns {Record<string, Array>} A map of contentTypeId to array of entry mapping objects.
  */
+/**
+ * Returns a human-readable title for an (entry, locale). Priority:
+ *   1. The content type's declared `displayField` value at this locale.
+ *   2. `title` or `name` at this locale (legacy fallback for CTs without a displayField).
+ *   3. First non-empty string field at this locale.
+ *   4. `sys.id` if the entry has SOME non-empty content at this locale but nothing readable.
+ * Returns null when the entry has no content at this locale at all — callers skip those,
+ * so we don't emit rows for locales an entry isn't actually localized to.
+ */
+const pickEntryTitle = (entry, locale, displayField) => {
+  const fields = entry?.fields || {};
+  const candidates = [displayField, 'title', 'name'].filter(Boolean);
+  for (const key of candidates) {
+    const val = fields?.[key]?.[locale];
+    if (typeof val === 'string' && val.trim()) return val;
+  }
+  let hasAnyLocaleContent = false;
+  for (const val of Object.values(fields)) {
+    if (val == null || typeof val !== 'object') continue;
+    if (!(locale in val)) continue;
+    hasAnyLocaleContent = true;
+    const localized = val[locale];
+    if (typeof localized === 'string' && localized.trim()) return localized;
+  }
+  return hasAnyLocaleContent ? entry?.sys?.id : null;
+};
+
 const extractEntries = (cleanLocalPath) => {
   try {
     const alldata = readFile(cleanLocalPath);
@@ -20,14 +47,20 @@ const extractEntries = (cleanLocalPath) => {
       return {};
     }
 
+    const displayFieldByCT = {};
+    for (const ct of alldata?.contentTypes ?? []) {
+      const id = ct?.sys?.id;
+      if (id) displayFieldByCT[id] = ct?.displayField;
+    }
+
     const entriesByContentType = {};
 
     for (const entry of entries) {
       const contentTypeId = entry?.sys?.contentType?.sys?.id;
       const entryId = entry?.sys?.id;
+      const displayField = displayFieldByCT[contentTypeId];
       for (const locale of locales) {
-        let entryTitle = entry?.fields?.title?.[locale];
-        entryTitle = !entryTitle ? entry?.fields?.name?.[locale] : entryTitle;
+        const entryTitle = pickEntryTitle(entry, locale, displayField);
         if (!entryTitle) continue;
         if (!entriesByContentType[contentTypeId]) {
           entriesByContentType[contentTypeId] = [];

--- a/upload-api/migration-contentful/libs/extractEntries.js
+++ b/upload-api/migration-contentful/libs/extractEntries.js
@@ -29,8 +29,12 @@ const pickEntryTitle = (entry, locale, displayField) => {
   for (const val of Object.values(fields)) {
     if (val == null || typeof val !== 'object') continue;
     if (!(locale in val)) continue;
-    hasAnyLocaleContent = true;
     const localized = val[locale];
+    // Key presence alone isn't "content" — Contentful can serialize a field as
+    // `{ "en-US": "" }` or `{ "en-US": null }` for a locale the entry isn't really
+    // localized to. Only count it once we see an actual non-empty value.
+    if (localized === null || localized === undefined || localized === '') continue;
+    hasAnyLocaleContent = true;
     if (typeof localized === 'string' && localized.trim()) return localized;
   }
   return hasAnyLocaleContent ? entry?.sys?.id : null;

--- a/upload-api/src/config/index.json
+++ b/upload-api/src/config/index.json
@@ -4,7 +4,7 @@
       "optionLimit": 100
     }
   },
-  "cmsType": "cmsType",
+  "cmsType": "contentful",
   "isLocalPath": true,
   "awsData": {
     "awsRegion": "us-east-2",
@@ -25,5 +25,5 @@
     "base_url": "drupal_assets_base_url",
     "public_path": "drupal_assets_public_path"
   },
-  "localPath": "your_local_cms_data_path"
+  "localPath": "/Users/chetan.narkhede/Desktop/migration-v2/asic-v1.json"
 }


### PR DESCRIPTION
## 🔗 Jira Tickets

Parent story: [CMG-789 — Delta Migration | v1.0.0](https://contentstack.atlassian.net/browse/CMG-789)

- [CMG-1101 — Iter 2 reference removed on entries](https://contentstack.atlassian.net/browse/CMG-1101)
- [CMG-1102 — asic_gender updated entries not shown on Map Entry](https://contentstack.atlassian.net/browse/CMG-1102)
- [CMG-1097 — Assets screen empty-state layout broken](https://contentstack.atlassian.net/browse/CMG-1097)
- [CMG-1103 — JSON RTE hyperlink URL lost in destination](https://contentstack.atlassian.net/browse/CMG-1103)
- [CMG-1104 — Entry Mapper selection lost across locales](https://contentstack.atlassian.net/browse/CMG-1104)
- [CMG-1095 — Delta iter 2+: not all content types displayed on Map Entry](https://contentstack.atlassian.net/browse/CMG-1095)

---

## 📋 PR Type

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [x] 🧹 Chore / Dependency Update
- [ ] ♻️ Refactor
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

- **CMG-1101** — Entry uid-mapper (flat + per-locale) threaded into the update config so `entry-update-script.cjs` resolves Link(Entry) fields on the delta/localize path; locale-migrated tracking moved after `updateEntryCli` resolves so silent failures don't permanently flag locales as done.
- **CMG-1102** — `extractEntries.js` now uses each content type's `displayField` with fallbacks (title → name → first localized string → sys.id) instead of hard-coded `title`/`name`, so entries with other display fields no longer disappear from Map Entry.
- **CMG-1097** — Asset mapper search-empty state: force `.Table` height when it contains an `.EmptyState` and center `.Table__centerWrapper` so the illustration + heading + description render properly.
- **CMG-1103** — JSON RTE hyperlinks rewritten to Contentstack's shape: plain `→ type:'a' attrs.url`, entry/asset `→ type:'reference'` with `display-type:'link'`. URLs now survive to destination.
- **CMG-1104** — Entry-mapper selection persists across locales: locale-scoped server toggle, stale-fetch generation guard, unified data-load effect, `tableRevision` remount so Venus's Table re-reads `initialSelectedRowIds`.
- **CMG-1095** — `getContentTypes` now unions content types from every prior iteration (1..N-1) instead of only N-1, so types migrated in earlier iterations but absent from N-1 are still classified as "old" on iteration N.
- Dep bumps to clear Snyk SLA (`fast-uri`, `brace-expansion`) in root and each sub-project package.
- Path-traversal SAST fixes on new file reads.

### Why?

Six independent delta-migration defects reported against v1.0.0. All share the same delta code paths so grouping keeps the review context tight.

---

## 🧩 Affected Areas

- [x] `api` — Node.js backend
- [x] `ui` — React frontend
- [x] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [x] Other: root `package.json` (dep override bumps)

---

## 🧪 How to Test

Fresh project on `bugfix/cmg-1101-ref-locale`. Migrate 3 iterations using the bundled fixtures.

1. **Iter 1** — `contentful-export.json` (3 CTs, 1 locale). Complete migration; references resolve in destination.
2. **Iter 2** — `asic.json` (24 CTs incl. `gender`/`moreInformation`/`tip`/`width` which use `internalTitle`). On Map Entry, all 24 should appear with entries. Save selections on multiple locales and verify each persists across locale switches.
3. **Iter 3** — `asic-merged.json` (27 CTs = iter 1's 3 + iter 2's 24). Map Entry should show **26** content types (one CT genuinely has 0 entries).
4. Assets tab → search for something not present → verify empty-state renders full illustration + heading + description below the header.
5. Any entry with a JSON RTE containing a plain hyperlink (e.g. ASIC `disclaimer`) → verify the link is preserved in the destination JSON RTE.
6. `cd api && npm test` passes.

**Expected result:** All 26 content types visible on iter 3 Map Entry; references and JSON RTE hyperlinks intact in destination; per-locale entry selections persist; assets search empty-state layout correct.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

- Parent story: [CMG-789](https://contentstack.atlassian.net/browse/CMG-789)

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `bugfix/cmg-1101-ref-locale`
- [x] Jira tickets linked above
- [x] Self-reviewed the diff
- [ ] `.env` / `example.env` updated — N/A
- [x] No secrets committed
- [x] Existing tests pass (`npm test` in `api/`)
- [x] New tests written for reference resolution helpers
- [ ] `README.md` / docs updated — N/A
- [x] Talisman pre-push scan passes

---

## 👀 Reviewer Notes

- Reference resolution precedence: per-locale new → per-locale old → flat new → flat old → identity fallback.
- CMG-1095 union-of-prior-iterations approach is O(iteration count) lowdb reads — fine for single-digit iterations.
- Dep bumps are in a separate concern from the delta fixes; splitting into its own PR would be cleaner but was kept here to unblock the Snyk SLA check.

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) · [Issues](https://github.com/contentstack/migration-v2/issues)