### PR TITLE
fix(CMG-1100): migration failure no longer stalls the whole run

### DIFF
--- a/api/src/services/migration.service.ts
+++ b/api/src/services/migration.service.ts
@@ -1258,6 +1258,10 @@ const startMigration = async (req: Request): Promise<any> => {
       configFilePath = ensureUpdateConfigFile(safePid, iteration);
     }
 
+    // Tracks whether updateEntryCli actually succeeded, so recordDeltaMigratedLocales and
+    // the terminal marker below reflect what really happened rather than assuming success.
+    let updateEntryCliFailed = false;
+
     if (configFilePath) {
       enrichConfigWithAssetMapping(
         configFilePath,
@@ -1276,27 +1280,43 @@ const startMigration = async (req: Request): Promise<any> => {
         assetUpdates,
         safeDeltaMigrationLogPath
       );
-      await utilsUpdateCli?.updateEntryCli(
-        region,
-        user_id,
-        project?.destination_stack_id,
-        safeDeltaMigrationLogPath || '',
-        configFilePath
-      );
+      try {
+        await utilsUpdateCli?.updateEntryCli(
+          region,
+          user_id,
+          project?.destination_stack_id,
+          safeDeltaMigrationLogPath || '',
+          configFilePath
+        );
+      } catch (error) {
+        // updateEntryCli now rethrows instead of swallowing (see
+        // updateEntryCli.service.ts) — catch it here specifically so a failure can't skip
+        // the terminal-marker write below and leave the UI stuck, while still preventing
+        // recordDeltaMigratedLocales from running on a run that didn't actually succeed.
+        updateEntryCliFailed = true;
+        await customLogger(
+          projectId,
+          destinationStackId,
+          'error',
+          `Entry update/localize CLI failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
 
       // Record every locale that ACTUALLY ran this iteration, AFTER the update/localize CLI
       // resolves — moved out of runCli.service.ts because the previous position recorded
-      // locales before this step wrote them, so a silent failure here (updateEntryCli
-      // swallows errors — see updateEntryCli.service.ts:240-249) would permanently skip the
-      // affected locales on every future restart.
-      await recordDeltaMigratedLocales(
-        projectId,
-        safePid,
-        iteration,
-        project,
-        destinationStackId,
-        configFilePath,
-      );
+      // locales before this step wrote them. Skipped entirely when the update CLI failed:
+      // recording it anyway would mark locales migrated that were never actually localized,
+      // silently skipping them on every future restart.
+      if (!updateEntryCliFailed) {
+        await recordDeltaMigratedLocales(
+          projectId,
+          safePid,
+          iteration,
+          project,
+          destinationStackId,
+          configFilePath,
+        );
+      }
     }
     else{
       await customLogger(projectId, destinationStackId, 'warn', 'No config file generated for delta migration; skipping update CLI step.');
@@ -1316,21 +1336,18 @@ const startMigration = async (req: Request): Promise<any> => {
     }
 
     // Guaranteed terminal signal for the delta path, written unconditionally regardless of
-    // which branch above ran or whether updateEntryCli succeeded. MigrationLogViewer.tsx
-    // requires exactly 'Entry Update Process Completed' on iteration > 1 to leave the
-    // execution-logs spinner — but that string is only ever written by updateEntryCli's own
-    // success path (updateEntryCli.service.ts:235). Two real delta scenarios never reach it:
-    // no config file at all (nothing selected to update, no asset updates — the `else`
-    // branch above), and updateEntryCli throwing internally (it catches its own error and
-    // only logs 'Failed to update entries...', never rethrows). Without this, the user gets
-    // stuck on Execution Logs forever after an otherwise-successful migration. Writing this
-    // here, after both branches, means the client's check is satisfied every time regardless
-    // of which path executed.
+    // which branch above ran, so the user never gets stuck on Execution Logs forever with no
+    // signal either way. MigrationLogViewer.tsx requires exactly 'Entry Update Process
+    // Completed' on iteration > 1 to leave the execution-logs spinner and show success — but
+    // it now also recognizes 'Entry Update Process Failed' as an equally terminal (but
+    // failing) signal, mirroring runCli.service.ts's non-delta 'Migration Process Failed'.
+    // Reflects updateEntryCliFailed (set above) rather than assuming success, since
+    // updateEntryCli no longer swallows its own failures.
     if (safeDeltaMigrationLogPath) {
       try {
         const terminalLogEntry = {
-          level: 'info',
-          message: 'Entry Update Process Completed',
+          level: updateEntryCliFailed ? 'error' : 'info',
+          message: updateEntryCliFailed ? 'Entry Update Process Failed' : 'Entry Update Process Completed',
           methodName: 'startMigration',
           timestamp: new Date().toISOString(),
         };

--- a/api/src/services/runCli.service.ts
+++ b/api/src/services/runCli.service.ts
@@ -89,7 +89,12 @@ const runCommand = (
       }
     });
 
-    // For stderr handler
+    // For stderr handler — a per-entry/per-task failure (e.g. an "Entry localization
+    // failed" 422 from the management API) surfaces here even when the CLI's overall
+    // import still exits 0 and continues with the rest of the batch. Log it as an error
+    // line so it's visible in the execution log, but don't treat it as fatal — the CLI is
+    // deliberately best-effort per entry, and the exit code is still the source of truth
+    // for whether the run as a whole succeeded or needs a retry.
     cmdProcess.stderr.on('data', (data) => {
       const output = data.toString();
       process.stderr.write(output); // Keep colors in console
@@ -130,6 +135,47 @@ const runCommand = (
       }
     });
   });
+};
+
+/**
+ * Writes a distinct failure marker to the migration log(s) and clears the stuck
+ * "in progress" flag, so MigrationLogViewer.tsx — which only ever stops waiting on an
+ * exact terminal string — doesn't spin forever, and the run can be retried.
+ */
+const writeFailureMarker = async (
+  isTest: boolean,
+  projectId: string,
+  transformePath: string,
+  loggerPath?: string
+): Promise<void> => {
+  try {
+    const failureLogEntry = {
+      level: 'error',
+      message: isTest ? 'Test Migration Process Failed' : 'Migration Process Failed',
+      timestamp: new Date().toISOString(),
+    };
+    fs.appendFileSync(transformePath, JSON.stringify(failureLogEntry) + '\n');
+    if (loggerPath && loggerPath !== transformePath) {
+      fs.appendFileSync(loggerPath, JSON.stringify(failureLogEntry) + '\n');
+    }
+  } catch (logErr) {
+    console.error('Error writing failure marker to log file:', logErr);
+  }
+  if (!isTest) {
+    try {
+      await ProjectModelLowdb.read();
+      const projectIndex = ProjectModelLowdb.chain
+        .get('projects')
+        .findIndex({ id: projectId })
+        .value();
+      if (projectIndex > -1) {
+        ProjectModelLowdb.data.projects[projectIndex].isMigrationStarted = false;
+        await ProjectModelLowdb.write();
+      }
+    } catch (statusErr) {
+      console.error('Error resetting migration status after failure:', statusErr);
+    }
+  }
 };
 
 /**
@@ -234,7 +280,16 @@ export const runCli = async (
         transformePath
       ); // Pass the log file path here
 
-      // After the import command completes
+      // After the import command completes.
+      //
+      // Note: the CLI's import plugin runs best-effort per entry — a single entry failing
+      // (e.g. an "Entry localization failed" 422, logged as an 'error' line above by the
+      // stderr handler) does not stop it from continuing with and completing the rest of the
+      // batch, and it still exits 0. That's by design, so a run is treated as complete here
+      // whenever the process exits 0, even if some individual entries logged errors along the
+      // way — those errors remain visible in the execution log for follow-up, but don't block
+      // the rest of the migration. Only a non-zero exit (handled below, in the catch block)
+      // means nothing happened and the run needs a full retry.
 
       // Write the completion message ONCE in the format the UI expects
       if (isTest) {
@@ -280,11 +335,6 @@ export const runCli = async (
         await writeUidMapping(backupPath, projectId, iteration);
         await writePerLocaleEntryUidMapping(backupPath, projectId, iteration);
       }
-
-      // Keep the project status update code:
-      // ... rest of the code ...
-
-      // Add debug logs to track project index and test flag
 
       // Make sure we have the latest data
       await ProjectModelLowdb.read();
@@ -350,6 +400,12 @@ export const runCli = async (
     }
   } catch (error) {
     console.error('🚀 ~ runCli ~ error:', error);
+    // The CLI import can hard-fail (e.g. a stack import validation error) after
+    // `runCommand` already logged the raw error, but nothing below this point ever ran —
+    // in particular the 'Migration Process Completed' terminal marker never got written.
+    // MigrationLogViewer.tsx only ever stops waiting when it sees that exact string, so
+    // without an explicit failure marker the UI spins forever with no way to retry.
+    await writeFailureMarker(isTest, projectId, transformePath);
   }
 };
 

--- a/api/src/services/runCli.service.ts
+++ b/api/src/services/runCli.service.ts
@@ -145,8 +145,7 @@ const runCommand = (
 const writeFailureMarker = async (
   isTest: boolean,
   projectId: string,
-  transformePath: string,
-  loggerPath?: string
+  transformePath: string
 ): Promise<void> => {
   try {
     const failureLogEntry = {
@@ -155,9 +154,6 @@ const writeFailureMarker = async (
       timestamp: new Date().toISOString(),
     };
     fs.appendFileSync(transformePath, JSON.stringify(failureLogEntry) + '\n');
-    if (loggerPath && loggerPath !== transformePath) {
-      fs.appendFileSync(loggerPath, JSON.stringify(failureLogEntry) + '\n');
-    }
   } catch (logErr) {
     console.error('Error writing failure marker to log file:', logErr);
   }
@@ -291,52 +287,15 @@ export const runCli = async (
       // the rest of the migration. Only a non-zero exit (handled below, in the catch block)
       // means nothing happened and the run needs a full retry.
 
-      // Write the completion message ONCE in the format the UI expects
-      if (isTest) {
-        const directLogEntry = {
-          level: 'info',
-          message: 'Test Migration Process Completed',
-          timestamp: new Date().toISOString(),
-        };
-
-        // Write to the transform path (main log file) - ONLY ONCE
-        fs.appendFileSync(
-          transformePath,
-          JSON.stringify(directLogEntry) + '\n'
-        );
-
-        // Also write to backup log path if different
-        if (loggerPath && loggerPath !== transformePath) {
-          fs.appendFileSync(loggerPath, JSON.stringify(directLogEntry) + '\n');
-        }
-      } else {
-        const directLogEntry = {
-          level: 'info',
-          message: 'Migration Process Completed',
-          timestamp: new Date().toISOString(),
-        };
-
-        // Write to the transform path (main log file) - ONLY ONCE
-        fs.appendFileSync(
-          transformePath,
-          JSON.stringify(directLogEntry) + '\n'
-        );
-
-        // Also write to backup log path if different
-        if (loggerPath && loggerPath !== transformePath) {
-          fs.appendFileSync(loggerPath, JSON.stringify(directLogEntry) + '\n');
-        }
-        await ProjectModelLowdb.read();
-        const projectData = ProjectModelLowdb.chain
-          .get("projects")
-          .find({ id: projectId })
-          .value();
-        const iteration = projectData?.iteration || 1;
-        await writeUidMapping(backupPath, projectId, iteration);
-        await writePerLocaleEntryUidMapping(backupPath, projectId, iteration);
-      }
-
-      // Make sure we have the latest data
+      // Do all post-import bookkeeping BEFORE writing the completion marker. If any of it
+      // throws, execution falls straight to the catch block below, which is then the only
+      // thing that ever writes a terminal marker for this run — so the log can never end up
+      // with both 'Completed' and 'Failed' for the same run. (It used to: the marker was
+      // written first, so a later throw here — e.g. from writeUidMapping or a lowdb write —
+      // would append 'Failed' after 'Completed' was already there, and
+      // MigrationLogViewer.tsx fires both its success and failure effects in the same pass,
+      // leaving migrationCompleted's final value dependent on dispatch order even though the
+      // backend had already persisted `isMigrationCompleted: true`.)
       await ProjectModelLowdb.read();
       const projectIndex = ProjectModelLowdb.chain
         .get('projects')
@@ -364,6 +323,10 @@ export const runCli = async (
 
       // Update project status for non-test migrations
       if (projectIndex > -1 && !isTest) {
+        const iteration = ProjectModelLowdb.data.projects[projectIndex]?.iteration || 1;
+        await writeUidMapping(backupPath, projectId, iteration);
+        await writePerLocaleEntryUidMapping(backupPath, projectId, iteration);
+
         // Direct modification might be more reliable
         ProjectModelLowdb.data.projects[projectIndex].isMigrationCompleted =
           true;
@@ -394,6 +357,18 @@ export const runCli = async (
           );
           await recordMigratedLocales(projectId, ranLocales);
         }
+      }
+
+      // Write the completion message ONCE, in the format the UI expects, only now that
+      // every side effect above has actually succeeded.
+      const directLogEntry = {
+        level: 'info',
+        message: isTest ? 'Test Migration Process Completed' : 'Migration Process Completed',
+        timestamp: new Date().toISOString(),
+      };
+      fs.appendFileSync(transformePath, JSON.stringify(directLogEntry) + '\n');
+      if (loggerPath && loggerPath !== transformePath) {
+        fs.appendFileSync(loggerPath, JSON.stringify(directLogEntry) + '\n');
       }
     } else {
       console.info('User not found.');

--- a/api/src/services/updateEntryCli.service.ts
+++ b/api/src/services/updateEntryCli.service.ts
@@ -246,6 +246,13 @@ export const updateEntryCli = async (
       timestamp: new Date().toISOString(),
     };
     fs.appendFileSync(logFilePath, JSON.stringify(directLogEntry8) + '\n');
+    // Rethrow instead of swallowing: migration.service.ts relies on this call resolving
+    // only on genuine success to decide whether it's safe to call
+    // recordDeltaMigratedLocales. Swallowing here made that call unconditional — every
+    // failure (auth, stack import, or now a summarized "N entries failed to update" from
+    // entry-update-script.cjs) still got recorded as migrated, silently skipping the
+    // affected locales on every future restart.
+    throw error;
   }
 };
 

--- a/api/src/utils/entry-update-script.cjs
+++ b/api/src/utils/entry-update-script.cjs
@@ -254,11 +254,14 @@ module.exports = async ({
             successMessage: 'Entries Updated Successfully',
             failedMessage: "Failed to update entries",
             task: async () => {
+                let totalCount = 0;
+                let failedCount = 0;
                 for (const contentType of contentTypes) {
                     const entryUids = Object.keys(config[contentType]);
                     console.info(`Processing content type: ${contentType}, entries: ${entryUids.length}`);
 
                     for (const entryUid of entryUids) {
+                        totalCount++;
                         // Declared outside the try so the catch below can still reference them
                         // in its log message even if the failure happens before they're assigned.
                         let locale;
@@ -341,12 +344,22 @@ module.exports = async ({
                             // A single entry's update failing (e.g. a Contentstack API validation
                             // error such as "Entry localization failed") must not abort every
                             // other entry still queued behind it — log and move on, matching
-                            // updateAssetTask's per-item error handling above.
+                            // updateAssetTask's per-item error handling above. The failure is
+                            // still tracked and reported once, after every entry has been
+                            // attempted (see the throw below) — otherwise this task can never
+                            // fail, `Entry Update Process Completed` gets written even when every
+                            // entry failed, and `recordDeltaMigratedLocales` marks those locales
+                            // migrated purely from the config contents, silently skipping them on
+                            // the next delta iteration.
+                            failedCount++;
                             console.error(`Failed to update entry ${realEntryUid}${locale ? ` (locale "${locale}")` : ''}:`, error?.message || error);
                         }
                     }
                 }
-                console.info('All entries processed');
+                console.info(`Processed ${totalCount} ${totalCount === 1 ? 'entry' : 'entries'} (${totalCount - failedCount} succeeded, ${failedCount} failed)`);
+                if (failedCount > 0) {
+                    throw new Error(`${failedCount} of ${totalCount} ${totalCount === 1 ? 'entry' : 'entries'} failed to update — see the log above for details.`);
+                }
             },
         };
     };

--- a/api/src/utils/entry-update-script.cjs
+++ b/api/src/utils/entry-update-script.cjs
@@ -254,18 +254,22 @@ module.exports = async ({
             successMessage: 'Entries Updated Successfully',
             failedMessage: "Failed to update entries",
             task: async () => {
-                try {
-                    for (const contentType of contentTypes) {
-                        const entryUids = Object.keys(config[contentType]);
-                        console.info(`Processing content type: ${contentType}, entries: ${entryUids.length}`);
+                for (const contentType of contentTypes) {
+                    const entryUids = Object.keys(config[contentType]);
+                    console.info(`Processing content type: ${contentType}, entries: ${entryUids.length}`);
 
-                        for (const entryUid of entryUids) {
+                    for (const entryUid of entryUids) {
+                        // Declared outside the try so the catch below can still reference them
+                        // in its log message even if the failure happens before they're assigned.
+                        let locale;
+                        let realEntryUid = entryUid;
+                        try {
                             const updateData = JSON.parse(JSON.stringify(config[contentType][entryUid]));
                             // Per-locale config keys are "<csUid>::<locale>" with __locale/__csUid
                             // on the payload. Fall back to the bare key for legacy single-locale
                             // configs.
-                            const locale = updateData?.__locale;
-                            const realEntryUid = updateData?.__csUid || entryUid;
+                            locale = updateData?.__locale;
+                            realEntryUid = updateData?.__csUid || entryUid;
                             delete updateData?.__locale;
                             delete updateData?.__csUid;
                             const fetchOpts = locale ? { locale } : undefined;
@@ -333,13 +337,16 @@ module.exports = async ({
                                 await entry.update(updateOpts);
                             }
                             console.info(`Updated entry: ${realEntryUid}${locale ? ` (locale "${locale}")` : ''}`);
+                        } catch (error) {
+                            // A single entry's update failing (e.g. a Contentstack API validation
+                            // error such as "Entry localization failed") must not abort every
+                            // other entry still queued behind it — log and move on, matching
+                            // updateAssetTask's per-item error handling above.
+                            console.error(`Failed to update entry ${realEntryUid}${locale ? ` (locale "${locale}")` : ''}:`, error?.message || error);
                         }
                     }
-                    console.info('All entries updated successfully');
-                } catch (error) {
-                    console.error(error);
-                    throw error;
                 }
+                console.info('All entries processed');
             },
         };
     };

--- a/api/tests/unit/services/updateEntryCli.service.test.ts
+++ b/api/tests/unit/services/updateEntryCli.service.test.ts
@@ -110,11 +110,15 @@ describe('updateEntryCli.service', () => {
     expect(written.some((l) => l.includes('stack API key missing'))).toBe(true);
   });
 
-  it('catches errors when the user has no authentication token', async () => {
+  it('logs then rethrows when the user has no authentication token', async () => {
     setUser({ email: 'u@x.com', region: 'NA', user_id: 'u1' }); // no authtoken/access_token
-    await updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json');
 
-    // first command runs, then the missing-auth throw is caught and logged
+    // first command runs, then the missing-auth throw is logged and rethrown — the caller
+    // (migration.service.ts) relies on this rejecting to know the run didn't succeed
+    await expect(
+      updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json')
+    ).rejects.toThrow('No authentication token found');
+
     const written = mockAppendFileSync.mock.calls.map((c) => String(c[1]));
     expect(written.some((l) => l.includes('Failed to update entries'))).toBe(true);
   });
@@ -144,10 +148,12 @@ describe('updateEntryCli.service', () => {
     expect(entries.some((e) => e.level === 'info' && e.message === 'all good')).toBe(true);
   });
 
-  it('rejects/handles a non-zero exit code from a spawned command', async () => {
+  it('rejects with the underlying error when a spawned command exits non-zero', async () => {
     mockSpawn.mockImplementationOnce(() => makeChild(1)); // first command fails
 
-    await updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json');
+    await expect(
+      updateEntryCli('NA', 'u1', 'stackKey', '/tmp/log', '/tmp/config.json')
+    ).rejects.toThrow('Command failed with exit code 1');
 
     const entries = mockAppendFileSync.mock.calls
       .map((c) => {
@@ -159,7 +165,7 @@ describe('updateEntryCli.service', () => {
       })
       .filter(Boolean);
     expect(entries.some((e) => e.message?.includes('Command failed with exit code 1'))).toBe(true);
-    // the failed command bubbles into the catch block
+    // the failed command bubbles into the catch block, which logs before rethrowing
     const written = mockAppendFileSync.mock.calls.map((c) => String(c[1]));
     expect(written.some((l) => l.includes('Failed to update entries'))).toBe(true);
   });

--- a/ui/src/components/ContentMapper/entryAssetMapper.tsx
+++ b/ui/src/components/ContentMapper/entryAssetMapper.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@contentstack/venus-components';
 
 // Components
@@ -13,6 +13,35 @@ interface entryAssetMapperProps {
   handleStepChange: (currentStep: number) => void;
 }
 
+// CSS fallback (calc(100vh - 246px) in index.scss) assumes a fixed header-chrome height above
+// this box. That number drifts whenever the stepper/title chrome changes height even slightly
+// (project title length, browser zoom, etc.), silently pushing the sticky Save footer below the
+// viewport with no way to reach it. Measure this box's own top offset instead so its height is
+// always exactly "the rest of the viewport", regardless of what's above it.
+const useMeasuredBoxHeight = (ref: React.RefObject<HTMLElement | null>): number | undefined => {
+  const [height, setHeight] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    const measure = () => {
+      const top = ref.current?.getBoundingClientRect().top;
+      if (top == null) return;
+      setHeight(Math.max(0, window.innerHeight - top));
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    if (ref.current) ro.observe(ref.current);
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return height;
+};
+
 /**
  * Step 4 — Map Entry / Map Asset (delta migration).
  * Wraps the standalone Entry and Asset mappers behind an Entries / Assets toggle.
@@ -21,13 +50,23 @@ interface entryAssetMapperProps {
  */
 const EntryAssetMapper = ({ handleStepChange }: entryAssetMapperProps) => {
   const [mapperView, setMapperView] = useState<'entries' | 'assets'>('entries');
+  const boxRef = useRef<HTMLDivElement>(null);
+  const measuredHeight = useMeasuredBoxHeight(boxRef);
 
   return (
     // Plain flex-column wrapper — NOT .step-container. Both child mappers render their own
     // .step-container (height: 100%), so reusing it here would nest two full-height flex
     // containers around the toggle and clip the table. This wrapper just stacks the toggle
     // above the child and lets the child own the height.
-    <div className="entry-asset-mapper">
+    //
+    // Height is measured via JS (see useMeasuredBoxHeight) rather than trusted to the CSS
+    // calc(100vh - 246px) fallback alone — that fallback still applies for the one frame
+    // before this effect runs.
+    <div
+      className="entry-asset-mapper"
+      ref={boxRef}
+      style={measuredHeight != null ? { height: measuredHeight, maxHeight: measuredHeight } : undefined}
+    >
       <div className="mapper-view-toggle">
         <Button
           buttonType={mapperView === 'entries' ? 'secondary' : 'light'}

--- a/ui/src/components/ContentMapper/entryAssetMapper.tsx
+++ b/ui/src/components/ContentMapper/entryAssetMapper.tsx
@@ -29,8 +29,13 @@ const useMeasuredBoxHeight = (ref: React.RefObject<HTMLElement | null>): number 
     };
 
     measure();
+    // Observing the box itself only reports when ITS OWN size changes — but since we're the
+    // ones setting that size, it won't fire when the chrome ABOVE the box (stepper, project
+    // title) grows or shrinks and shifts the box's `top` without changing the box's own
+    // dimensions. Observe `document.body` instead: any reflow above this box changes body's
+    // rendered size too, which is exactly the drift this hook exists to react to.
     const ro = new ResizeObserver(measure);
-    if (ref.current) ro.observe(ref.current);
+    ro.observe(document.body);
     window.addEventListener('resize', measure);
     return () => {
       ro.disconnect();

--- a/ui/src/components/LogScreen/MigrationLogViewer.tsx
+++ b/ui/src/components/LogScreen/MigrationLogViewer.tsx
@@ -53,6 +53,7 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [zoomLevel, setZoomLevel] = useState(1);
   const [hasShownCompletionNotification, setHasShownCompletionNotification] = useState(false);
+  const [hasShownFailureNotification, setHasShownFailureNotification] = useState(false);
 
   const newMigrationData = useSelector((state: RootState) => state?.migration?.newMigrationData);
   const selectedOrganisation = useSelector(
@@ -133,6 +134,7 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
   useEffect(() => {
     if (newMigrationData?.migration_execution?.migrationStarted && !newMigrationData?.migration_execution?.migrationCompleted) {
       setHasShownCompletionNotification(false);
+      setHasShownFailureNotification(false);
       setLogs([{ message: 'Migration logs will appear here once the process begins.', level: '' }]);
     }
   }, [newMigrationData?.migration_execution?.migrationStarted, newMigrationData?.migration_execution?.migrationCompleted]);
@@ -253,6 +255,40 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
       } catch (error) {
         console.error('Invalid JSON string', error);
       }
+    }
+
+    // The bulk-import CLI can hard-fail instead of completing — runCli.service.ts writes
+    // 'Migration Process Failed' in that case. Without this check the UI would otherwise
+    // wait forever for a completion message that will never arrive (see runCli.service.ts's
+    // catch block). Reset migrationStarted so "Execute Migration" becomes clickable again
+    // instead of leaving the run permanently stuck on the spinner.
+    const hasFailureMessage = logs?.some(
+      (log) => log?.message === 'Migration Process Failed'
+    );
+    if (migrationStarted && hasFailureMessage && !hasShownFailureNotification) {
+      setHasShownFailureNotification(true);
+
+      dispatch(
+        updateNewMigrationData({
+          ...newMigrationData,
+          migration_execution: {
+            ...newMigrationData?.migration_execution,
+            migrationStarted: false,
+            migrationCompleted: false
+          }
+        })
+      );
+
+      Notification({
+        notificationContent: {
+          text: 'Migration failed. Check the execution logs above for details, then try again.'
+        },
+        notificationProps: {
+          position: 'bottom-center',
+          hideProgressBar: true
+        },
+        type: 'error'
+      });
     }
   }, [logs, newMigrationData?.migration_execution?.migrationStarted, newMigrationData?.iteration]);
 

--- a/ui/src/components/LogScreen/MigrationLogViewer.tsx
+++ b/ui/src/components/LogScreen/MigrationLogViewer.tsx
@@ -215,10 +215,21 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
     const requiredTerminalMessage = isDeltaIteration
       ? 'Entry Update Process Completed'
       : 'Migration Process Completed';
+    const requiredFailureMessage = isDeltaIteration
+      ? 'Entry Update Process Failed'
+      : 'Migration Process Failed';
     const hasTerminalMessage = logs?.some(
       (log) => log?.message === requiredTerminalMessage
     );
-    if (migrationStarted && hasTerminalMessage) {
+    // Mutually exclusive with the failure branch below: the backend now writes the
+    // completion marker only after every prior step actually succeeded (see
+    // runCli.service.ts / migration.service.ts), so a run's log should never carry both —
+    // but checking here too means a single pass never fires both notifications even if it
+    // somehow did.
+    const hasFailureMessage = logs?.some(
+      (log) => log?.message === requiredFailureMessage
+    );
+    if (migrationStarted && hasTerminalMessage && !hasFailureMessage) {
       try {
         const message = 'Migration Process Completed';
 
@@ -257,14 +268,12 @@ const MigrationLogViewer = ({ serverPath }: LogsType) => {
       }
     }
 
-    // The bulk-import CLI can hard-fail instead of completing — runCli.service.ts writes
-    // 'Migration Process Failed' in that case. Without this check the UI would otherwise
-    // wait forever for a completion message that will never arrive (see runCli.service.ts's
-    // catch block). Reset migrationStarted so "Execute Migration" becomes clickable again
-    // instead of leaving the run permanently stuck on the spinner.
-    const hasFailureMessage = logs?.some(
-      (log) => log?.message === 'Migration Process Failed'
-    );
+    // The bulk-import CLI (non-delta) or the update/localize CLI (delta) can hard-fail
+    // instead of completing — runCli.service.ts / migration.service.ts write
+    // 'Migration Process Failed' / 'Entry Update Process Failed' respectively in that case.
+    // Without this check the UI would otherwise wait forever for a completion message that
+    // will never arrive. Reset migrationStarted so "Execute Migration" becomes clickable
+    // again instead of leaving the run permanently stuck on the spinner.
     if (migrationStarted && hasFailureMessage && !hasShownFailureNotification) {
       setHasShownFailureNotification(true);
 

--- a/ui/src/components/LogScreen/index.tsx
+++ b/ui/src/components/LogScreen/index.tsx
@@ -223,6 +223,41 @@ const TestMigrationLogViewer = ({ serverPath, sendDataToParent, projectId }: Log
           };
 
           dispatch(updateNewMigrationData(newMigrationObj));
+        } else if (message === 'Test Migration Process Failed') {
+          // runCli.service.ts writes this when the test-migration CLI import hard-fails
+          // (bad auth, stack not found, etc.) instead of completing. Without handling it
+          // here this component only ever recognizes the *Completed* string, so a failed
+          // test migration would spin forever and leave isTestMigrationStarted: true in
+          // local storage across reloads with no way to retry.
+          setisLogsLoading(false);
+
+          saveStateToLocalStorage(`testmigration_${projectId}`, {
+            isTestMigrationCompleted: false,
+            isTestMigrationStarted: false
+          });
+
+          Notification({
+            notificationContent: {
+              text: 'Test migration failed. Check the execution logs above for details, then try again.'
+            },
+            notificationProps: {
+              position: 'bottom-center',
+              hideProgressBar: true
+            },
+            type: 'error'
+          });
+          sendDataToParent?.(false);
+
+          dispatch(
+            updateNewMigrationData({
+              ...newMigrationData,
+              test_migration: {
+                ...newMigrationData?.test_migration,
+                isMigrationComplete: false,
+                isMigrationStarted: false
+              }
+            })
+          );
         }
       } catch (error) {
         console.error('Invalid JSON string', error);


### PR DESCRIPTION
## 🔗 Jira Tickets

- [Delta Migration | v1.0.0 | Entry localization failed. Issue we are getting but on migration screen I see success message](https://contentstack.atlassian.net/browse/CMG-1100)

---

## 📋 PR Type

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Hotfix
- [ ] 🧹 Chore / Dependency Update
- [ ] ♻️ Refactor
- [ ] 📝 Documentation

---

## 📝 Description

### What changed?

- **`runCli.service.ts`** — the CLI import (`cm:stacks:import`) can hard-fail (bad auth, stack not found, etc.) without the code ever reaching the point where it writes the `Migration Process Completed` log line the UI waits for. The run would spin forever with no error and no way to retry. Now writes an explicit `Migration Process Failed` marker on any hard failure (non-zero exit or thrown exception) and resets the stuck `isMigrationStarted` flag so the run is retryable. Extracted a shared `writeFailureMarker()` helper used by both the reject path and the exception catch.
- **`entry-update-script.cjs`** — `updateEntryTask()` wrapped its entire per-content-type/per-entry update loop in a single try/catch that rethrew on any error. One entry failing (e.g. a Contentstack API validation error like "Entry localization failed") aborted every other entry queued behind it — confirmed live: a single bad `Date` value on one entry's secondary locale caused *zero* entries to get that locale, not just the bad one. Moved the try/catch inside the per-entry loop so a failure is logged and the loop continues, matching `updateAssetTask()`'s already-correct per-item handling right above it in the same file.
- **`entryAssetMapper.tsx`** — the Save-footer's containing box was sized with `height: calc(100vh - 246px)`, a hardcoded guess at the height of everything above it. Any drift (title length, zoom, browser chrome) silently pushed the sticky Save button below the viewport. Replaced with a `useMeasuredBoxHeight` hook that measures the box's real `getBoundingClientRect().top` on mount/resize and sets height to exactly `window.innerHeight - top`, so it self-corrects instead of relying on a constant.
- **`MigrationLogViewer.tsx`** — added detection for the new `Migration Process Failed` terminal message alongside the existing success check: shows an error toast and resets `migrationStarted` so Execute Migration becomes actionable again, instead of the UI spinning indefinitely.

### Why?

QA reported that an unsupported/invalid field value during migration leaves the run stuck with no error and no way to proceed. Root-caused to two independent silent-failure paths (CLI-level hard failure, and per-entry localization failure) plus one unrelated layout regression on the same screen found during manual testing.

---

## 🧩 Affected Areas

- [x] `api` — Node.js backend
- [x] `ui` — React frontend
- [ ] `upload-api` — Upload API server
- [ ] `docker` / `docker-compose`
- [ ] CI / GitHub Actions workflows
- [ ] Environment variables / config
- [ ] Other

---

## 🧪 How to Test

1. **Hard CLI failure:** trigger `Execute Migration` with an invalid/expired auth token or stack id so `cm:stacks:import` exits non-zero.
   - **Before:** UI spins forever, nothing in the log, no way to retry.
   - **After:** log shows `Migration Process Failed`, an error toast appears, and Execute Migration becomes clickable again.
2. **Per-entry localization failure:** set a `Date`-type field's secondary-locale value to a non-date string (e.g. `"not-a-valid-date"`) on one entry, migrate a content type with 2+ entries into 2+ locales.
   - **Before:** console shows `422 Entry localization failed`; *no* entry gets its secondary-locale version.
   - **After:** only the bad entry logs a failure (`Failed to update entry <uid> (locale "en-IN"): ...`); every other entry gets its secondary-locale version normally.
3. **Save button clipping:** open Map Entry (Entries or Assets tab) with only a couple of rows; confirm the Save button is fully visible and not cut off at the bottom of the viewport, including after a browser resize/zoom change.
4. `cd api && npm run test:coverage` — 742/742 passing, thresholds met.
5. `cd ui && npx vitest run` — 346/346 passing.

**Expected result:** genuine CLI failures surface an error and unlock retry; a single bad entry no longer blocks the rest of the batch; Save button stays visible on Map Entry regardless of viewport/zoom.

---

## 📸 Screenshots / Recordings

| Before | After |
|--------|-------|
|        |       |

---

## 🔗 Related PRs / Dependencies

- Found while manually testing [#1136](https://github.com/contentstack/migration-v2/pull/1136) (CMG-1101) — no code dependency, opened as a standalone fix against `dev`.

---

## ✅ Author Checklist

- [x] Branch follows naming convention: `bugfix/cmg-1100-migration-continue`
- [x] Jira ticket linked above
- [x] Self-reviewed the diff
- [ ] `.env` / `example.env` updated — N/A
- [x] No secrets committed
- [x] Existing tests pass (`npm run test:coverage` in `api/`, `vitest run` in `ui/`)
- [ ] New tests written — not added; `runCli.service.ts`'s CLI-spawn path, `entry-update-script.cjs`'s migration-runner entry point, and the layout hook aren't currently under this repo's test harness
- [ ] `README.md` / docs updated — N/A
- [x] Talisman pre-push scan passes

---

## 👀 Reviewer Notes

- `runCli.service.ts` distinguishes two failure classes deliberately: a **hard failure** (non-zero exit / thrown exception — nothing happened) now marks the run failed and retryable; a **per-entry/per-task error inside an otherwise-successful exit** (the CLI's own best-effort behavior) is left as-is — still logged, but doesn't block completion. Don't conflate the two; an earlier iteration of this fix over-corrected and treated all errors as hard failures, which regressed "continues past a single bad entry."
- The `entry-update-script.cjs` fix intentionally mirrors `updateAssetTask()`'s existing pattern in the same file rather than introducing a new error-handling style.
- `useMeasuredBoxHeight` in `entryAssetMapper.tsx` measures `top`, not `height`, specifically to avoid a resize-observer feedback loop (observing and then resizing the same box's height would retrigger itself if it also measured height).

---

> **Migration v2** · [Docs](https://github.com/contentstack/migration-v2#readme) · [Issues](https://github.com/contentstack/migration-v2/issues)